### PR TITLE
Mocha qe baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.zip
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+data/*
+outputs/*
 *.zip
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+## Setup environment using Conda
+
+1. Initialize a new [conda](https://docs.anaconda.com/anaconda/install/) 
+environment (e.g., using Python 3.9).
+2. Activate the conda environment by executing the command in your terminal:
+```
+$ conda activate <conda-env-name>
+```
+
+3. Install pytorch by executing the command below:
+
+```
+$ python -m pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 torchaudio==0.8.2 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+```
+
+3. Install `allennlp` and HuggingFace `datasets` using the `requirements.txt`, by
+executing the following command:
+
+```
+$ python -m pip install -r requirements.txt
+```
+
+Note: In the outline above, we assume you are have CULDA TOOLKIT 11. You will
+have to update the version in step 2 accordingly, in case your version differs.
+Moreover, note that since `allennlp` version 2.5.0 requires pytorch 1.8, we
+opt for pre-installing that version in our environment.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Note: In the outline above, we assume you are have CULDA TOOLKIT 11. You will
 have to update the version in step 2 accordingly, in case your version differs.
 Moreover, note that since `allennlp` version 2.5.0 requires pytorch 1.8, we
 opt for pre-installing that version in our environment.
+
+
+## Running 
+
+```
+$ allennlp train training_config/qasper_eqqa.jsonnet -s data/qasper_models --include-package quality_estimation
+```

--- a/quality_estimation/mocha_eqqa_reader.py
+++ b/quality_estimation/mocha_eqqa_reader.py
@@ -149,18 +149,8 @@ class MochaEqqaReader(DatasetReader):
             + tokenized_context
         )
 
-        if len(answer_question) < self.max_document_length:
-            original_answer_question_length = len(answer_question)
-            padding_length = self.max_document_length - original_answer_question_length
-            answer_question = answer_question + [Token(self._padding_token)] * padding_length
-            attention_mask = ([True] * original_answer_question_length) + ([False] * padding_length)
-        else:
-            attention_mask = [True for _ in answer_question]
-
         input_ids = TextField(answer_question)
         fields["input_text"] = input_ids
-        # make the attention mask field
-        fields["attention_mask"] = TensorField(torch.tensor(attention_mask))
 
         # Apply min-max scaling
         if (target_correctness < 1) or (target_correctness > 5):

--- a/quality_estimation/mocha_eqqa_reader.py
+++ b/quality_estimation/mocha_eqqa_reader.py
@@ -155,13 +155,13 @@ class MochaEqqaReader(DatasetReader):
             attention_mask = [True for _ in answer_question]
 
         input_ids = TextField(answer_question)
-        fields["input_ids"] = input_ids
+        fields["input_text"] = input_ids
         # make the attention mask field
         fields["attention_mask"] = TensorField(torch.tensor(attention_mask))
-        fields["target_correctness"] = TensorField(torch.tensor([target_correctness]))
+        fields["target_correctness"] = TensorField(torch.tensor([target_correctness], dtype=torch.float16))
 
         return Instance(fields)
 
     @overrides
     def apply_token_indexers(self, instance: Instance) -> None:
-        instance.fields["input_ids"].token_indexers = self._token_indexers
+        instance.fields["input_text"].token_indexers = self._token_indexers

--- a/quality_estimation/mocha_eqqa_reader.py
+++ b/quality_estimation/mocha_eqqa_reader.py
@@ -152,16 +152,11 @@ class MochaEqqaReader(DatasetReader):
         fields["attention_mask"] = TensorField(torch.tensor(attention_mask))
 
         # Apply min-max scaling
-        if (target_correctness < 1).any() or (target_correctness > 5).any():
+        if (target_correctness < 1) or (target_correctness > 5):
             logger.warning(f"Target correctness should be in the interval (1, 5) but {target_correctness}.")
 
         target = (target_correctness - 1) / (5-1)
-
-            
         fields["target_correctness"] = TensorField(torch.tensor([target], dtype=torch.float16))
-        
-
-        logger.info(f"Truncated instances: {self._log_data['truncated instances']}")
         return Instance(fields)
 
     @overrides

--- a/quality_estimation/mocha_eqqa_reader.py
+++ b/quality_estimation/mocha_eqqa_reader.py
@@ -1,0 +1,167 @@
+import json
+import logging
+import random
+from enum import Enum
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Iterable, Tuple, Union
+
+from overrides import overrides
+
+import spacy
+import torch
+
+from allennlp.common.util import JsonDict
+from allennlp.data.fields import (
+    MetadataField,
+    TextField,
+    IndexField,
+    ListField,
+    TensorField,
+)
+from allennlp.common.file_utils import cached_path, open_compressed
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from allennlp.data.instance import Instance
+from allennlp.data.token_indexers import PretrainedTransformerIndexer
+from allennlp.data.tokenizers import Token, PretrainedTransformerTokenizer
+
+
+logger = logging.getLogger(__name__)
+
+
+@DatasetReader.register("mocha_eqqa")
+class MochaEqqaReader(DatasetReader):
+    def __init__(
+        self,
+        transformer_model_name: str = "roberta-base",
+        max_answer_length: int = 100,
+        max_query_length: int = 100,
+        max_document_length: int = 512,
+        exclude_datasets: Optional[List[str]] = None,
+        include_context: bool = True,
+        paragraph_separator: Optional[str] = "</s>",
+        padding_token: Optional[str] = "<pad>",
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            manual_distributed_sharding=True,
+            manual_multiprocess_sharding=True,
+            **kwargs,
+        )
+        self._transformer_model_name = transformer_model_name
+        self._tokenizer = PretrainedTransformerTokenizer(
+            transformer_model_name, add_special_tokens=False
+        )
+
+        self._token_indexers = {
+            "tokens": PretrainedTransformerIndexer(transformer_model_name)
+        }
+
+        self.max_answer_length = max_answer_length
+        self.max_query_length = max_query_length
+        self.max_document_length = max_document_length
+        self.exclude_datasets = exclude_datasets
+
+        self.include_context = include_context
+        
+        self._paragraph_separator = paragraph_separator
+        self._padding_token = padding_token
+        
+        self._log_data = defaultdict(int)
+
+    @overrides
+    def _read(self, file_path: str):
+        # if `file_path` is a URL, redirect to the cache
+        file_path = cached_path(file_path)
+
+        logger.info("Reading json file at %s", file_path)
+        with open_compressed(file_path) as dataset_file:
+            data = json.load(dataset_file)
+        
+        for dataset_name, dataset in self.shard_iterable(data.items()):
+            # Skip dataset if user restricted the datasets to train on
+            if (self.exclude_datasets is not None and dataset_name in self.exclude_datasets):
+                continue
+
+            yield from self._dataset_to_instances(dataset)
+
+        logger.info("Stats:")
+        for key, value in self._log_data.items():
+            logger.info(f"{key}: {value}")
+
+
+    def _dataset_to_instances(self, dataset: Dict[str, Any]) -> Iterable[Instance]:
+        # Each dataset is composed of {example_id1: example, ...}        
+
+        for example_id, example in dataset.items():
+            example_context = example["context"] if self.include_context else None
+
+            yield self.text_to_instance(
+                context=example_context,
+                question=example["question"],
+                answer=example["answer"],
+                target_correctness=example["correctness"],
+            )
+
+    @overrides
+    def text_to_instance(
+        self,  # type: ignore  # pylint: disable=arguments-differ
+        question: str,
+        answer: str,
+        target_correctness: float,
+        context: str = None,
+    ) -> Instance:
+        def _tokenize(text, max_length):
+            tokenized_text = self._tokenizer.tokenize(text)
+            if len(tokenized_text) > max_length:
+                tokenized_text = tokenized_text[:self.max_length]
+
+            return tokenized_text
+
+        fields = {}
+
+        tokenized_question = _tokenize(question, self.max_query_length)
+        tokenized_answer = _tokenize(answer, self.max_answer_length)
+
+        # Determine remaining length for context (if specified)
+        allowed_context_length = (
+                self.max_document_length
+                - len(tokenized_question)
+                - len(tokenized_answer)
+                - 2  # for paragraph separators
+        )
+
+        use_context = context is not None
+        tokenized_context = _tokenize(context, allowed_context_length) \
+            if use_context else []
+                
+
+        if use_context and len(tokenized_context) > allowed_context_length:
+            self._log_data["truncated instances"] += 1
+
+        answer_question = (
+            tokenized_answer
+            + [Token(self._paragraph_separator)]
+            + tokenized_question
+            + [Token(self._paragraph_separator)]
+            + tokenized_context
+        )
+
+        if len(answer_question) < self.max_document_length:
+            original_answer_question_length = len(answer_question)
+            padding_length = self.max_document_length - original_answer_question_length
+            answer_question = answer_question + [Token(self._padding_token)] * padding_length
+            attention_mask = ([True] * original_answer_question_length) + ([False] * padding_length)
+        else:
+            attention_mask = [True for _ in answer_question]
+
+        input_ids = TextField(answer_question)
+        fields["input_ids"] = input_ids
+        # make the attention mask field
+        fields["attention_mask"] = TensorField(torch.tensor(attention_mask))
+        fields["target_correctness"] = TensorField(torch.tensor([target_correctness]))
+
+        return Instance(fields)
+
+    @overrides
+    def apply_token_indexers(self, instance: Instance) -> None:
+        instance.fields["input_ids"].token_indexers = self._token_indexers

--- a/quality_estimation/mocha_eqqa_reader.py
+++ b/quality_estimation/mocha_eqqa_reader.py
@@ -158,7 +158,10 @@ class MochaEqqaReader(DatasetReader):
         fields["input_text"] = input_ids
         # make the attention mask field
         fields["attention_mask"] = TensorField(torch.tensor(attention_mask))
-        fields["target_correctness"] = TensorField(torch.tensor([target_correctness], dtype=torch.float16))
+
+        # Apply min-max scaling
+        target = (target_correctness - 1) / (5-1)
+        fields["target_correctness"] = TensorField(torch.tensor([target], dtype=torch.float16))
 
         return Instance(fields)
 

--- a/quality_estimation/mocha_eqqa_reader.py
+++ b/quality_estimation/mocha_eqqa_reader.py
@@ -121,6 +121,7 @@ class MochaEqqaReader(DatasetReader):
             - len(tokenized_answer)
             - 1 # paragraph selector
         )
+        allowed_question_length = min(self.max_query_length, allowed_question_length)
         tokenized_question, truncated_question = \
             _tokenize(question, allowed_question_length)
 

--- a/quality_estimation/mocha_eqqa_reader.py
+++ b/quality_estimation/mocha_eqqa_reader.py
@@ -113,7 +113,7 @@ class MochaEqqaReader(DatasetReader):
         def _tokenize(text, max_length):
             tokenized_text = self._tokenizer.tokenize(text)
             if len(tokenized_text) > max_length:
-                tokenized_text = tokenized_text[:self.max_length]
+                tokenized_text = tokenized_text[:max_length]
 
             return tokenized_text
 

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -18,19 +18,6 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 @Model.register("mocha_eqqa_roberta")
 class MochaQualityEstimator(Model):
-    def _init_layers(self):
-        for m in self.modules():
-            if isinstance(m, torch.nn.Conv2d):
-                torch.nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
-                if m.bias is not None:
-                    torch.nn.init.constant_(m.bias, 0)
-            elif isinstance(m, torch.nn.BatchNorm2d):
-                torch.nn.init.constant_(m.weight, 1)
-                torch.nn.init.constant_(m.bias, 0)
-            elif isinstance(m, torch.nn.Linear):
-                torch.nn.init.normal_(m.weight, 0, 0.01)
-                torch.nn.init.constant_(m.bias, 0)     
-
 
     def __init__(
         self,
@@ -65,8 +52,6 @@ class MochaQualityEstimator(Model):
                 torch.nn.Linear(hidden_size, 1),
                 ])
         self.regression_layer = torch.nn.Sequential(*self.regression_layer)
-        self._init_layers()
-
         self.loss = MSELoss()
 
         # ----------------------------------------------------------------

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -77,7 +77,7 @@ class MochaQualityEstimator(Model):
 
     @property
     def embedding_dim(self):
-        return self.transformer.embeddings.word_embeddings.embedding_dim
+        return self.transformer.config.hidden_size
 
     def forward(
         self,

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -41,8 +41,7 @@ class MochaQualityEstimator(Model):
         **kwargs
     ):
         super().__init__(vocab, **kwargs)
-        config = AutoConfig.from_pretrained(transformer_model_name)
-        self.transformer = AutoModel.from_pretrained(transformer_model_name, config=config)
+        self.transformer = AutoModel.from_pretrained(transformer_model_name)
 
         # We do not want to train the base transformer models
         if not train_base:

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -57,7 +57,7 @@ class QasperQualityEstimator(Model):
         # Define **METRICS** head
         # ----------------------------------------------------------------
         self._mae_metric = MeanAbsoluteError()
-        self._pearson_metric =  PearsonCorrelation()
+        # self._pearson_metric =  PearsonCorrelation()
 
     @property
     def embedding_dim(self):
@@ -101,7 +101,7 @@ class QasperQualityEstimator(Model):
             output_dict["target_correctness"] = target_correctness
 
             self._mae_metric(prediction, target_correctness)
-            self._pearson_metric(prediction, target_correctness)
+            # self._pearson_metric(prediction, target_correctness)
 
         return output_dict
 
@@ -109,7 +109,7 @@ class QasperQualityEstimator(Model):
     def get_metrics(self, reset: bool=False) -> Dict[str, float]:
        
         result = self._mae_metric.get_metric(reset)
-        result["pearson"] =  self._pearson_metric.get_metric(reset) 
+        # result["pearson"] =  self._pearson_metric.get_metric(reset) 
         ## ^Note: apparently MAE returns a dictionary, whereas
         ## pearson correlation returns one value
         return result

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -37,7 +37,7 @@ class MochaQualityEstimator(Model):
         vocab: Vocabulary,
         transformer_model_name: str = "roberta-base",
         hidden_size: int = 1,
-        train_base: bool = False,
+        train_base: bool = True,
         **kwargs
     ):
         super().__init__(vocab, **kwargs)

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -1,0 +1,115 @@
+from typing import Dict
+from overrides import overrides
+from allennlp.data import TextFieldTensors, Vocabulary
+from allennlp.models.model import Model
+from allennlp.modules import FeedForward
+from allennlp.nn import util
+from allennlp.training.metrics import MeanAbsoluteError, PearsonCorrelation
+
+import torch
+from torch.nn import MSELoss
+from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+import logging
+
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+@Model.register("mocha_eqqa_roberta")
+class QasperQualityEstimator(Model):
+    def __init__(
+        self,
+        vocab: Vocabulary,
+        transformer_model_name: str = "roberta-base",
+        hidden_size: int = 1,
+        **kwargs
+    ):
+        super().__init__(vocab, **kwargs)
+        config = AutoConfig.from_pretrained(transformer_model_name)
+        self.transformer = AutoModel.from_pretrained(transformer_model_name, config=config)
+
+        # We do not want to train the base transformer models
+        for _, param in self.transformer.named_parameters():
+            param.requires_grad = False
+        
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            transformer_model_name,
+            add_special_tokens=False
+        )
+        
+        # ----------------------------------------------------------------
+        # Define **Regression** head
+        # ----------------------------------------------------------------
+        self.regression_layer = [
+            torch.nn.Linear(self.embedding_dim, hidden_size),
+        ]
+        if hidden_size > 1:
+            self.regression_layer.extend([
+                torch.nn.ReLU(inplace=True),
+                torch.nn.Linear(hidden_size, 1),
+                ])
+        self.regression_layer = torch.nn.Sequential(*self.regression_layer)
+        
+        self.loss = MSELoss()
+
+        # ----------------------------------------------------------------
+        # Define **METRICS** head
+        # ----------------------------------------------------------------
+        self._mae_metric = MeanAbsoluteError()
+        self._pearson_metric =  PearsonCorrelation()
+
+    @property
+    def embedding_dim(self):
+        return self.transformer.embeddings.word_embeddings.embedding_dim
+
+    def forward(
+        self,
+        input_text: TextFieldTensors,
+        attention_mask: torch.Tensor,
+        target_correctness: torch.Tensor = None,
+    ) -> Dict[str, torch.Tensor]:
+
+        input_ids = util.get_token_ids_from_text_field_tensors(input_text)
+        
+        # FIXME 
+        # - Why do we overwrite our attention mask? 
+        attention_mask = util.get_text_field_mask(input_text)
+
+        output = self.transformer(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            return_dict=True
+        )
+        # (batch_size, lf_hidden_size)
+        regression_input = output['pooler_output']
+        # ^Note: 
+        # https://huggingface.co/docs/transformers/v4.18.0/en/main_classes/output#transformers.modeling_outputs.BaseModelOutputWithPoolingAndCrossAttentions.pooler_output
+        
+        # (batch_size, 1)
+        prediction = self.regression_layer(regression_input)
+        # FIXME
+        # - Should we clip (1, 5)?
+
+        output_dict = {
+            "predicted_correctness": prediction,
+        }
+
+        if target_correctness is not None:
+            loss = self.loss(prediction, target_correctness)
+            output_dict["loss"] = loss
+            output_dict["target_correctness"] = target_correctness
+
+            self._mae_metric(prediction, target_correctness)
+            self._pearson_metric(prediction, target_correctness)
+
+        return output_dict
+
+    @overrides
+    def get_metrics(self, reset: bool=False) -> Dict[str, float]:
+       
+        result = self._mae_metric.get_metric(reset)
+        result["pearson"] =  self._pearson_metric.get_metric(reset) 
+        ## ^Note: apparently MAE returns a dictionary, whereas
+        ## pearson correlation returns one value
+        return result

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @Model.register("mocha_eqqa_roberta")
-class QasperQualityEstimator(Model):
+class MochaQualityEstimator(Model):
     def __init__(
         self,
         vocab: Vocabulary,
@@ -88,8 +88,7 @@ class QasperQualityEstimator(Model):
         
         # (batch_size, 1)
         prediction = self.regression_layer(regression_input)
-        # FIXME
-        # - Should we clip (1, 5)?
+        prediction = torch.sigmoid(prediction)
 
         output_dict = {
             "predicted_correctness": prediction,
@@ -99,6 +98,9 @@ class QasperQualityEstimator(Model):
             loss = self.loss(prediction, target_correctness)
             output_dict["loss"] = loss
             output_dict["target_correctness"] = target_correctness
+
+            if target_correctness < 0 or target_correctness > 1:
+                logger.warning(f"\n\ntarget correctness: {target_correctness.max()}")
 
             self._mae_metric(prediction, target_correctness)
             # self._pearson_metric(prediction, target_correctness)

--- a/quality_estimation/mocha_eqqa_roberta_model.py
+++ b/quality_estimation/mocha_eqqa_roberta_model.py
@@ -83,14 +83,10 @@ class MochaQualityEstimator(Model):
     def forward(
         self,
         input_text: TextFieldTensors,
-        attention_mask: torch.Tensor,
         target_correctness: torch.Tensor = None,
     ) -> Dict[str, torch.Tensor]:
 
         input_ids = util.get_token_ids_from_text_field_tensors(input_text)
-        
-        # FIXME 
-        # - Why do we overwrite our attention mask? 
         attention_mask = util.get_text_field_mask(input_text)
 
         output = self.transformer(

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+rm -rf outputs/$1
+allennlp train training_config/mocha_eqqa.jsonnet -s outputs/$1 --include-package quality_estimation

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
-rm -rf outputs/$1
-allennlp train training_config/mocha_eqqa.jsonnet -s outputs/$1 --include-package quality_estimation
+rm -rf outputs/models/$1
+allennlp train training_config/mocha_eqqa.jsonnet -s outputs/models/$1 --include-package quality_estimation

--- a/scripts/mocha_eqqa_preprocessing.ipynb
+++ b/scripts/mocha_eqqa_preprocessing.ipynb
@@ -2,34 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "142a84d5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "dev.json\t    minimal_pairs.json.sha1   train.json\r\n",
-      "dev.json.sha1\t    test_no_labels.json       train.json.sha1\r\n",
-      "minimal_pairs.json  test_no_labels.json.sha1\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import pandas as pd\n",
     "import numpy as np\n",
     "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import seaborn as sns\n",
-    "\n",
-    "MOCHA_DIR_PATH = \"../../datasets/mocha\"\n",
+    "MOCHA_DIR_PATH = \"..\"\n",
     "!ls {MOCHA_DIR_PATH}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "818936ad",
    "metadata": {},
    "outputs": [],
@@ -42,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f5da3cd7",
    "metadata": {},
    "outputs": [],
@@ -64,16 +50,16 @@
     "        \"correctness\": 5, # assumption\n",
     "        \"correctness_std\": 0,   # more realistic assumption could depend \n",
     "                                # on how many wrong answers we find in the data.\n",
+    "        \"_metadata\": str({}),\n",
     "    }\n",
     "    candidate = {\n",
     "        \"question\": example[\"question\"],\n",
     "        \"context\": example[\"context\"],\n",
     "        \"answer\": example[\"candidate\"],\n",
-    "        \"is_reference\": True,\n",
+    "        \"is_reference\": False,\n",
     "        \"correctness\": example[\"score\"],\n",
     "        \"correctness_std\": np.std(example[\"metadata\"][\"scores\"]),\n",
-    "        \"_source\": example[\"metadata\"][\"scores\"],\n",
-    "        \"_original_scores\": example[\"metadata\"][\"scores\"],\n",
+    "        \"_metadata\": str(example[\"metadata\"]),\n",
     "    }\n",
     "            \n",
     "    return reference, candidate\n",
@@ -127,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "499e884b",
    "metadata": {},
    "outputs": [],
@@ -137,23 +123,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "6be71bbc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5033\n",
-      "687\n",
-      "7210\n",
-      "7471\n",
-      "3259\n",
-      "7409\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 31069 train examples if consider every dataset\n",
     "new_data, new_data_candidates_only = preprocess_data(\n",
@@ -165,23 +138,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "5a94dcaa",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "683\n",
-      "97\n",
-      "978\n",
-      "890\n",
-      "344\n",
-      "1017\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 4009 dev examples if consider every dataset\n",
     "preprocess_data(\n",
@@ -203,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "e26a1fbc",
    "metadata": {},
    "outputs": [],
@@ -252,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "4ff739ae",
    "metadata": {},
    "outputs": [],
@@ -267,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "5c9431c3",
    "metadata": {},
    "outputs": [],
@@ -279,6 +239,486 @@
     "    output_dir=OUTPUT_DIR,\n",
     ");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af10b79d",
+   "metadata": {},
+   "source": [
+    "## Check MOCHA dataset statistics "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d109ce9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd \n",
+    "import numpy as np\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import json\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "58c34e1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Length of training and dev datasets (including both ref and candidate scores): 49713 12425 8018\n",
+      "Length of training and dev candidates only: 24858 6211 4009\n"
+     ]
+    }
+   ],
+   "source": [
+    "def load_dataset(filepath):\n",
+    "    data = json.load(open(filepath))\n",
+    "\n",
+    "    all_datasets_df = []\n",
+    "    for dataset_name, dataset_examples in data.items():\n",
+    "\n",
+    "        examples_to_df = []\n",
+    "        for example_id, example in dataset_examples.items():\n",
+    "            example[\"dataset\"] = dataset_name\n",
+    "            example[\"example_id\"] = example_id        \n",
+    "            examples_to_df.append(example)\n",
+    "\n",
+    "        df = pd.DataFrame(examples_to_df)\n",
+    "        all_datasets_df.append(df)\n",
+    "\n",
+    "\n",
+    "    data = pd.concat(all_datasets_df).reset_index(drop=True)\n",
+    "    return data\n",
+    "\n",
+    "\n",
+    "train_data = load_dataset(\"../data/mocha_eqqa_data/split__train_all.json\")\n",
+    "dev_data = load_dataset(\"../data/mocha_eqqa_data/split__dev_all.json\")\n",
+    "test_data = load_dataset(\"../data/mocha_eqqa_data/original__dev_all.json\")\n",
+    "print(\"Length of training and dev datasets (including both ref and candidate scores):\", len(train_data), len(dev_data), len(test_data))\n",
+    "\n",
+    "\n",
+    "train_cand_data = load_dataset(\"../data/mocha_eqqa_data/split__train_candidates_only.json\")\n",
+    "dev_cand_data = load_dataset(\"../data/mocha_eqqa_data/split__dev_candidates_only.json\")\n",
+    "test_cand_data = load_dataset(\"../data/mocha_eqqa_data/original__dev_candidates_only.json\")\n",
+    "print(\"Length of training and dev candidates only:\", len(train_cand_data), len(dev_cand_data), len(test_cand_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "f4df3c31",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3gAAAGDCAYAAAB5pLK9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABUZklEQVR4nO3debwcVZn4/8/DJZBAAiIERLIhssoSMQkgCgiyqGwKDCijIJs6g8sPdHR0vshgFBk1royCosiiIChMFBwQIbIqWQgoIBiRJJcJEgKEgASS8Pz+qLqk07lL35vb6b59P+/Xq1+3q+r0qaf6dj19TtWp6shMJEmSJEkD3zqNDkCSJEmS1D/s4EmSJElSi7CDJ0mSJEktwg6eJEmSJLUIO3iSJEmS1CLs4EmSJElSi7CDtxZFxK8j4oQ1eP25EfGJfgyplnWeGBG3V0w/FxGvq6XsQBER4yIiI2Ldfqpvi4i4NSKWRMTX+qPOeouIj0bEeY2OQwNHRKwfEQ9ExJZreb3TIuKU8vnxEXFjLWUHkog4OyIu68f63h0R88v8/cb+qreeIuLuiHhDo+PQwBURd6ztz3tEXBwRk8vnb42Ih2opO5D0d1svIvaOiL+U+enI/qq3niLi5xHxjkbH0R07eD0oP3Adj5cj4oWK6eN7U1dmviMzf9zHOEYCHwAu6Mvr+0tmDs/MR9a0nv5uwDSZ04AngY0y88xGB1Oj7wPHR8TmjQ5EfRMRj5b5aUlEPBMRd0bEhyOiXnn+NODWzFxQp/p7lJmXZ+ZB/VFX+f69vT/qakJfBU4v8/c9jQ6mRl8Fzml0EFpz/dmOKuvr8cBNRBwGLGnk5z0zb8vM7fujroF6sKpG5wDfKfPTtY0OpkbnAU3dObeD14PyAzc8M4cD84DDKuZd3lGuv87+dONE4PrMfKHO61E3avw/jwUeyMysU/39LjOXAr+mOIiggeuwzBxB8Rn8MvBp4KI6revDwKV1qls16kVOur+O9dfDVOBtEfGaBq1f/aTWdlQ/Mz81gVbNT5l5N7BRRExoxPprYQevjyJiv4hoj4hPR8TjwI8iYpOI+FVELIyIp8vnoypeUzm06MSIuD0ivlqW/VsPp3vfAfyuKoYjImJ2RDwbEX+NiEPK+R+MiAfLI/mPRMSHOon7zIh4IiIWRMQHK5ZvGhFTyzrvBrapWmdGxOtrLPvNcljQsxExMyLeWs4/BPgscGx5BO/ecv7GEXFRGdNjETE5Itq6eP8nRcRd5ZmKBRHxnYhYryrOD5en/Z+JiPMjIsplbeX7/mREPAK8q5v3vePI/qcj4j7g+YhYNyL2LM+QPBMR90bEfmXZi4ETgH8rt+3tEbFORHym/B8tioifRcSry/Idw0NPjoh5wM3l/JPK/+HTEXFDRIytZdvK5adW/P8fiIjdy/mvjWJYwcLy8/axqk2d1tN7oYEhMxdn5lTgWOCEiNgZXhlW+dWImBcRf4+I70XEsHLZgxFxaEcd5ed8Ycfnp1JEjAFeB/yhYt6wiPhaRMyNiMVlfuuo+6qIeLycf2tUDL2LYpjS+RFxXfmZ/UNEbFOx/MCI+HP52u8AlZ/16iHk3ZXdJiJuLvfBJyPi8oh4VbnsUmAM8Mtyv/23cn6n+3lnKvbxjv3u3dVxRhf5PiK2jojfla/9DbBZN+vp7Lun0xxT/r+fA9qAeyPir2UdXeaCKEZXXB0Rl0XEs8CJ0U1urmHbXh0RP4qI/yuXX1ux7NAovsM6zjjv2rGsPOg0Ezi4q/dCA1tXn9ty2dDyM7io/HxMj+Lyhy8CbwW+U+6r3+mk3vWA/aloM0Xxvf/Zin10ZkSMLpd9Mzppq5TLzi7juqR83f1R0aiPiDdGxKxy2ZXA0Ipl+0VEe41lN4ku2o9dbXNE7BARv4mIpyLioYj4p27e6w9GndqFVevpVZumzEmvY2XuXb+GfHNHRHw9IhYBZ0f332s9bVt331s95f9pNHObKTN91PgAHgXeXj7fD1hOcZp2fWAYsClwFLABMAK4Cri24vXTgFPK5ycCy4BTKb58PwL8HxBdrHshMLFiehKwGDiQoqO+FbBDuexdFDtgAPsC/wB2r4r7HGAI8M5y+Sbl8iuAnwEbAjsDjwG3V6w3gdfXWPafy/dkXeBM4HFgaLnsbOCyqm28hmII6obA5sDdwIe6eD/eBOxZ1j0OeBD4RFWcvwJeRdFwWwgcUi77MPBnYDTwauCWsvy63fzfZ5flh5Xv9aLyvVun/B8sAkaW5S8GJle8/uPA74FR5WflAuCn5bJx5bovKbd7GHAEMAfYsdy+/wDurHHbjin/DxPL///rKY6OrUPRWDoLWI8ioT4CHFxR7+7AU43ez3z07UFFfqqaPw/4SPn86xRnRl5NkaN+CZxbLjsLuLzide8CHuxiXe8C7q+adz5FjtuKIqe9GVi/XHZSub71gW8Asyted3G5/0wqP++XA1eUyzYDlgBHU+Sr/48if1Xm0dtrLPv6cl9dHxgJ3Ap8o6v3jx72807ek2OA15ZljwWeB7asiLPLfA/cBUwpY9un3I7LuljPfqz+3dNljilfU5m3u80FFLl5GXBkWXYY3eTmGrbtOuBKYJPy/7JvOf+NwBPAHuXrTij/B+tXxP0tYEqj9y0f/fdg1XZUd9+NH6LITxuUn483UVz2ABVtqS7W8Qbg+ap5nwL+CGxP8d24G7BpuayntspSijzQBpwL/L5cth4wlyLXDKHIPcsov//LfbW9xrI1tx/L6Q2B+cAHy7jfSHFpyE5dvCd1axdWrWccvW/TvPKZKKd7yjfLgY+WdQ2j+++1nrat0+8tasj/wBnALxq9T3W5HzQ6gIH0YPUO3kuUSaCL8uOBpyumX9lByw/pnIplG5Q7xWu6qGsZZQeunL4A+HqNcV8LfLwi7heo6MxQfMnuWX64q9fzJTrp4NVStpM4ngZ2K5+fTUUDBtgCeBEYVjHvvcAtNW7jJ4BrquJ8S8X0z4DPlM9vBj5csewgeu7gnVQx/Wng0qoyNwAnlM8vZtUO3oPAARXTW5bvXUfnNIHXVSz/NXByxfQ6FAlpbA3bdkPH/7oqvj2AeVXz/h34UcX0tsCKeu0/Pur7oOsO3u+Bz1F8sT8PbFOxbC/gb+Xz11N0LDYopy8HzupiXcdTNnLK6XXKvLJbDXG+qvwMb1xOXwz8oGL5O4E/l88/ULWeANrpvIPXbdlO4jgSuKer96+n/byG7ZwNHFERZ6f5nuIgzXJgw4rlP6H7Dt4q3z10k2PK6coOXre5gCI331qxrNvc3MO2bQm8TNmYqlrnd4EvVM17iLIDWE5/EfhhI/YnH/V5sGo7qrvvxpOAO4FdO6ljWlf7dbl8b+DxqnkPdeyPNcRY3Va5qWLZTsAL5fN9qDowX8bcWQev27KdxDCeLtqP5fSxwG1Vr7kA+HyN23gt/dQurKp3HL1v01R+JmrJN/MqlvX0vdbdtnX5vUUN+Z/ioNbNa3P/6c2jUWPrW8XCLIaRABARG1AcSTiE4mglwIiIaMvMFZ28/vGOJ5n5jyhG2Q3vYl1PUxyZ6DAauL6zglEMj/k8sB3FB3gDiiNXHRZl5vKK6X+U6x1JkVjnVyyb20U8PZaNiE8CJ1Mc1U5gI7oeejSW4ujKglg52nCdqvor696O4oj3BIrtW5fiqHSlxyued2wjZTy1bGOlyvJjgWOiuIi7wxCKM4GdGQtcExEvV8xbQZHIuqr/m7HqHTiD4ohSR6xdbdto4K9dxPDaiHimYl4bcFvF9AiKs8JqLVsBT1HssxsAMyv2saD4HJCZcyLiQeCwiPglcDjFUeHOVOejzSiGG6322SuH1nyR4gzXSIoGf8drOj5vNe2rmZkR0WlO6KlsRGwBfJNiqNMIivzydBd1QS/384j4AMUR3XHlrOGsmu+6yvebUTTknq8oO5diX+7KKt89dJ9jHutku3rKBdX5qKfc3NW2vZpiVEBn7/NYiuHDH62Ytx7F/7HDCKAyTrWW7j63l1LsA1dEMZT6MuBzmbmshnqr8xN0/d1YS1ulOj8NjeLar9cCj2XZ2i911Z7otmwf2o9jgT2q9uN16eK6w7XULqzU2zZNZdme8k3l826/10pdbVuX31vUlv+bOj/ZwVszWTV9JsXp/z0y8/GIGA/cQ8V1IGvgPoodc3o5PZ9OxkFHxPrAzymOZv9PZi6L4pqHWmJYSHEkeTTFEEYoji73umwUY9j/DTiAYijXyxHxdEUc1e/dfIqjNptV7Yhd+S7Fe/vezFwSxc9HHF3D6wAWsGrjqattrFQZ73yKIzun1ri++RRnAO+oXhAR47qo/4vZt4vPO/1clPP/lpnbdvPaHYF7+7BONamImEjxJXo7xfCdF4A3ZGZ1o7/DTymOlq5DcaOgOV2Uuw/YOiLWLffXJymGMW3D6p+h91EM0Xk7xZHajSkaYLXkpFX21Si+wbvq+PRU9ksU+9kumflUFLfjrrx+p7OcVNN+Xl5P8n2KfHdXZq6IiNnUvo2bRMSGFZ28MZ3EU6mzWDvNMZ2oJRdU56Pe5Obqdb06Il6Vmc90suyLmfnFbl6/I0XDXq2pp8/tfwL/WX5PXk9xFu4iut83oBgOGBGxVUWu6/hu/FNlwRraKt1ZAGwVEVHRcRtD5x2Gnsr21H7sbJ//XWYe2FOQa7FdWKmvbZpa8k1l3bV8r3Wlu++tWvJ/U7eZvMlK/xpB8UF7JooLhT/fj3VfTzFuusNFwAcj4oAoLlTeKiJ2oDgCuj7lTlketanpNuLlUaJfUFy0ukFE7ERxXURfyo6gSAoLgXUj4iyKo2Id/g6Mi/IW7lncav1G4GsRsVG5TdtEROU2VxoBPAs8V273R2rZxtLPgI9FxKiI2AT4TC9eC0WD47CIODiKC7eHlhfyjuqi/PeAL8bKi4pHRsQR3dT/PeDfo7wRRRQXHB9TY2w/AD4ZEW+KwuvL9d4NLInixgzDyrh3LjsAHfalGEqhAa7chw6luHbissz8Y2a+TNEJ+XqUP4dR5o3Km1hcQZEvPkIxTLBTmdlO0YiaVE6/DPwQmBLFDTzaImKvsmExguILexHFkdYv9WJTrgPeEBHvKY+Yf4xi6F9fyo4AngMWR8RWFNfkVPo7xfVoHXqzn29I0ehYCMUNDSiuVelRZs4FZlA0ZNeLiLcAh/Xwsmq9yTG15ILK+Hqbm6tf+2vgv6O4icSQiNinXPx94MMRsUeZqzaMiHdFxIhyG4ZSXHf1m168DxpYuvzcRsTbImKXKEYAPEsxTLDjTF/1vrqKzHwJuIlV20w/AL4QEduWn7ddI2JTem6rdOeu8rUfKz/b76HMiX0o21P7sXqbfwVsFxHvL+sbEhETI2LHTta9VtqF3ai5TdPbfFPj91pX29bd91Yt+b+p20x28PrXNygu+HyS4rqX/+3Hui8B3hnl3X2yuEXrBylO6S+muFvU2MxcQtGw+RnFUfL3UVx8WqvTKU5dP05xbcyP+lj2Bortf5jiFPxSVj2tflX5d1FEzCqff4AiET1Qxn41xZj8znySYtuWUOzcV/a0YRW+X8Z3LzCLInnVLDPnU5yR+CxFwpxP0Vjsan/6JsX/4MaIWELx2dijm/qvobiBwhVR3MXuTxR3Ua0ltqsohsP9hOK9uRZ4dZmkD6UY1/83is/oDyjOpnQ0pt4J9Ol3GtU0fll+xuZTXHc3hSJPdPg0Rcfs9+Vn6yaKo8bAK1+ud1FcaN7TPnUB8P6K6U9SDPmZTjEk9DyKfeISihzwGMW+/ftaNyYzn6QY2vllig7itkCnR/trKPufFDcSWkzRGaze788F/iOKO6Z9sjf7eWY+AHyN4r37O7BLV3F24X0UOeEpiobdJb14LfQix/SUC7rQm9xc7f0UjfM/U1z78okyjhkU17B8p6xzDsX1NR0OA6Zl5v/VuB4NPN19bl9D8Tl7luJavd+xcvjhN4Gjo7gj47e6qLs6P02haBfdWNZ5EUV7rae2SpfKjuR7KD63T1FcF9dpe6KGst+g+/bjKttctvUOAo6juLbvcVbeeKl63WuzXbiaPrRpeptvuv1e60Gn31s95f/ygNhzZVu8KXXc5UoDQER8CXgiM7/R6FjUWqK4DmZ0Zv5bo2PRwFAe5byH4iYJDfuxc7WmiPgDxY0Z/tRjYakTEXEHcHo28MfO1Zoi4ufARZnZ6b0wmoEdPEmSJElqEQ7RlCRJkqQWYQdPkiRJklqEHTxJkiRJahF28CRJkiSpRQy4HzrfbLPNcty4cY0OQ1I/mjlz5pOZObLRcawJc5PUmsxPkppRd7lpwHXwxo0bx4wZMxodhqR+FBFzGx3DmjI3Sa3J/CSpGXWXmxyiKUmSJEktwg6eJEmSJLWIunbwIuKQiHgoIuZExGc6WX5iRCyMiNnl45R6xiNJkiRJraxu1+BFRBtwPnAg0A5Mj4ipmflAVdErM/P0NVnXsmXLaG9vZ+nSpWtSTcsYOnQoo0aNYsiQIY0ORRrUzE2rMjdJzcP8tCrzk1pJPW+yMgmYk5mPAETEFcARQHUHb421t7czYsQIxo0bR0T0d/UDSmayaNEi2tvb2XrrrRsdjjSomZtWMjdJzcX8tJL5Sa2mnkM0twLmV0y3l/OqHRUR90XE1RExui8rWrp0KZtuuumgT1AAEcGmm27qETmpCZibVjI3qZ7GjRlFRNT0GDdmVKPDbQrmp5XMT2o1jf6ZhF8CP83MFyPiQ8CPgf2rC0XEacBpAGPGjOm0IhPUSr4XqpdxY0Yxd/5jNZUdO3orHp3XXueIGsvc1Du+F6qXufMfI2/+Uk1lY//P1jma5mB+6h3fC9VLI9pO9ezgPQZUnpEbVc57RWYuqpj8AfBfnVWUmRcCFwJMmDAh+zdMSbWyEbUqc5OkZmV+kppDI9pO9RyiOR3YNiK2joj1gOOAqZUFImLLisnDgQf7a+VvfvOb+6uq1Vx11VXsuOOOvO1tb6vbOiS1JnOTpGZlfpJaQ93O4GXm8og4HbgBaAN+mJn3R8Q5wIzMnAp8LCIOB5YDTwEn9tf677zzzjV6/YoVK2hra+t02UUXXcT3v/993vKWt9RU1/Lly1l33UaPhpXUDMxNkpqV+UlqDXX9HbzMvD4zt8vMbTLzi+W8s8rOHZn575n5hszcLTPflpl/7q91Dx8+HIAFCxawzz77MH78eHbeeWduu+22bl9z5plnsttuu3HXXXdx2WWXMWnSJMaPH8+HPvQhVqxYwTnnnMPtt9/OySefzKc+9SlWrFjBpz71KSZOnMiuu+7KBRdcAMC0adN461vfyuGHH85OO+3Ubbn99tuPo48+mh122IHjjz+ezGIkxfTp03nzm9/MbrvtxqRJk1iyZEmX9UgaGMxNkpqV+UlqDS1/aOQnP/kJBx98MJ/73OdYsWIF//jHP7os+/zzz7PHHnvwta99jQcffJDzzjuPO+64gyFDhvAv//IvXH755Zx11lncfPPNfPWrX2XChAlceOGFbLzxxkyfPp0XX3yRvffem4MOOgiAWbNm8ac//Ymtt96623L33HMP999/P6997WvZe++9ueOOO5g0aRLHHnssV155JRMnTuTZZ59l2LBhXHTRRZ3W4219pYHF3CSpWZmfpIGt5Tt4EydO5KSTTmLZsmUceeSRjB8/vsuybW1tHHXUUQD89re/ZebMmUycOBGAF154gc0333y119x4443cd999XH311QAsXryYv/zlL6y33npMmjTpleTRU7lRo4rbNo8fP55HH32UjTfemC233PKV9W+00Ubd1mOSkgYWc5OkZmV+kga2lu/g7bPPPtx6661cd911nHjiiZxxxhl84AMf6LTs0KFDXxk7npmccMIJnHvuud3Wn5l8+9vf5uCDD15l/rRp09hwww1rKrf++uu/Mt3W1sby5ct7vT5JA4u5SVKzMj9JA1tdr8FrBnPnzmWLLbbg1FNP5ZRTTmHWrFk1ve6AAw7g6quv5oknngDgqaeeYu7cuauVO/jgg/nud7/LsmXLAHj44Yd5/vnn+1yuw/bbb8+CBQuYPn06AEuWLGH58uW9rkdSczI3SWpW5idpYGv5M3jTpk3jK1/5CkOGDGH48OFccsklNb1up512YvLkyRx00EG8/PLLDBkyhPPPP5+xY8euUu6UU07h0UcfZffddyczGTlyJNdee+1q9dVarsN6663HlVdeyUc/+lFeeOEFhg0bxk033dTreiQ1J3OTpGZlfpIGtui469BAMWHChJwxY8Yq8x588EF23HHHBkXUnHxPVA8R0asf66w1v0TEzMycsCaxNZq5qTa+J6qHeuWmsm7z0yDhe6J6aETbqeWHaEqSJEnSYNHyQzQ7s8cee/Diiy+uMu/SSy9ll112aVBEkmRuktS8zE/SwDEoO3h/+MMfGh2CJK3G3CSpWZmfpIHDIZqSJEmS1CLs4EmSJElSi7CDJ0mSJEktYlBeg7c2tLW1rXLh8bXXXsu4ceM6LTt8+HCee+65tRSZpMHM3CSpWZmfpP4xKDp4o8eMpX3+vH6rb9ToMcyfN7fbMsOGDWP27Nn9tk5JrcfcJKlZmZ+kgWtQdPDa589jyo0P9Vt9Zxy0fa9f89xzz3HEEUfw9NNPs2zZMiZPnswRRxyxSpkFCxZw7LHH8uyzz7J8+XK++93v8ta3vpUbb7yRz3/+87z44otss802/OhHP2L48OH9tTmSGsTcJKlZmZ+kgctr8OrkhRdeYPz48YwfP553v/vdDB06lGuuuYZZs2Zxyy23cOaZZ672S/U/+clPOPjgg5k9ezb33nsv48eP58knn2Ty5MncdNNNzJo1iwkTJjBlypQGbZWkgc7cJKlZmZ+k/jEozuA1QvUwg2XLlvHZz36WW2+9lXXWWYfHHnuMv//977zmNa95pczEiRM56aSTWLZsGUceeSTjx4/nd7/7HQ888AB77703AC+99BJ77bXX2t4cSS3C3CSpWZmfpP5hB28tufzyy1m4cCEzZ85kyJAhjBs3jqVLl65SZp999uHWW2/luuuu48QTT+SMM85gk0024cADD+SnP/1pgyKX1MrMTZKalflJ6huHaK4lixcvZvPNN2fIkCHccsstzJ27+oXGc+fOZYsttuDUU0/llFNOYdasWey5557ccccdzJkzB4Dnn3+ehx9+eG2HL6lFmZskNSvzk9Q3dT2DFxGHAN8E2oAfZOaXuyh3FHA1MDEzZ9QzpkY5/vjjOeyww9hll12YMGECO+yww2plpk2bxle+8hWGDBnC8OHDueSSSxg5ciQXX3wx733ve3nxxRcBmDx5Mtttt93a3gRJLcjcJKlZmZ+kvqlbBy8i2oDzgQOBdmB6REzNzAeqyo0APg78oV6xjBo9pk93b+quvp5U/zbLZpttxl133dVt2RNOOIETTjhhteX7778/06dP70OkkpqZuUlSszI/SQNXPc/gTQLmZOYjABFxBXAE8EBVuS8A5wGfqlcgPf3uiiQ1grlJUrMyP0kDVz2vwdsKmF8x3V7Oe0VE7A6Mzszr6hiHJEmSJA0KDbvJSkSsA0wBzqyh7GkRMSMiZixcuLD+wUlSDcxNkpqV+UkavOrZwXsMGF0xPaqc12EEsDMwLSIeBfYEpkbEhOqKMvPCzJyQmRNGjhxZx5AlqXbmJknNyvwkDV717OBNB7aNiK0jYj3gOGBqx8LMXJyZm2XmuMwcB/weOLxV76IpSZIkSfVWtw5eZi4HTgduAB4EfpaZ90fEORFxeL3WK0mSJEmDVV1/By8zrweur5p3Vhdl96tnLGvTokWLOOCAAwB4/PHHaWtro2N4xN133816663XyPAkDVLmJknNyvwk9Z+6dvCaxbgxo5g7/7GeC9Zo7OiteHRee5fLN910U2bPng3A2WefzfDhw/nkJz/5yvLly5ez7rqD4q2X1A1zk6RmZX6SBq5BsafMnf8YefOX+q2+2P+zvX7NiSeeyNChQ7nnnnvYe++92WijjVZJXjvvvDO/+tWvGDduHJdddhnf+ta3eOmll9hjjz347//+b9ra2votfknNwdwkqVmZn6SBq2E/kzAYtbe3c+eddzJlypQuyzz44INceeWV3HHHHcyePZu2tjYuv/zytRilpMHG3CSpWZmfpN4bFGfwmsUxxxzT49Gk3/72t8ycOZOJEycC8MILL7D55puvjfAkDVLmJknNyvwk9Z4dvLVoww03fOX5uuuuy8svv/zK9NKlSwHITE444QTOPffctR6fpMHJ3CSpWZmfpN5ziGaDjBs3jlmzZgEwa9Ys/va3vwFwwAEHcPXVV/PEE08A8NRTTzF37tyGxSlpcDE3SWpW5iepNnbwGuSoo47iqaee4g1veAPf+c532G677QDYaaedmDx5MgcddBC77rorBx54IAsWLGhwtJIGC3OTpGZlfpJqMyiGaI4dvVWf7t7UXX21OvvsszudP2zYMG688cZOlx177LEce+yxfQlN0gBibpLUrMxP0sA1KDp43f3uiiQ1irlJUrMyP0kDV01DNCPisIhwOKckSZIkNbFaO23HAn+JiP+KiB3qGZAkSZIkqW9q6uBl5j8DbwT+ClwcEXdFxGkRMaKu0fVCZjY6hKbheyE1D/fHlXwvpObiPrmS74VaSc3DLjPzWeBq4ApgS+DdwKyI+GidYqvZ0KFDWbRokTsnRYJatGgRQ4cObXQo0qBnblrJ3CQ1F/PTSuYntZqabrISEUcAJwKvBy4BJmXmExGxAfAA8O26RViDUaNG0d7ezsKFCxsZRtMYOnQoo0aNanQY0qBnblqVuUlqHuanVZmf1EpqvYvme4CvZ+atlTMz8x8RcXL/h9U7Q4YMYeutt250GJK0CnOTpGZlfpJaV61DNB+v7txFxHkAmfnbfo9KkiRJktRrtXbwDuxk3jv6MxBJkiRJ0prpdohmRHwE+Bdgm4i4r2LRCOCOegYmSZIkSeqdnq7B+wnwa+Bc4DMV85dk5lN1i0qSJEmS1Gs9DdHMzHwU+FdgScWDiHh1T5VHxCER8VBEzImIz3Sy/MMR8ceImB0Rt0fETr3fBEmSJEkS1HYG71BgJpBAVCxL4HVdvTAi2oDzKa7fawemR8TUzHygsv7M/F5Z/nBgCnBIbzdCkiRJktRDBy8zDy3/9uU+upOAOZn5CEBEXAEcQfG7eR31P1tRfkOKTqMkSZIkqQ96usnK7t0tz8xZ3SzeCphfMd0O7NHJOv4VOANYD9i/u/VJkiRJkrrW0xDNr3WzLOmHDllmng+cHxHvA/4DOKG6TEScBpwGMGbMmDVdpST1C3OTpGZlfpIGr56GaL5tDep+DBhdMT2qnNeVK4DvdhHHhcCFABMmTHAYp6SmYG6S1KzMT9Lg1dMQzf0z8+aIeE9nyzPzF928fDqwbURsTdGxOw54X1X922bmX8rJdwF/QZIkSZLUJz0N0dwXuBk4rJNlCXTZwcvM5RFxOnAD0Ab8MDPvj4hzgBmZORU4PSLeDiwDnqaT4ZmSJEmSpNr0NETz8+XfD/al8sy8Hri+at5ZFc8/3pd6JUmSJEmr6+mHzgGIiE0j4lsRMSsiZkbENyNi03oHJ0mSJEmqXU0dPIoboCwEjgKOLp9fWa+gJEmSJEm919M1eB22zMwvVExPjohj6xGQJEmSJKlvaj2Dd2NEHBcR65SPf6K4eYokSZIkqUn09DMJSyjulhnAJ4DLykXrAM8Bn6xncJIkSZKk2vV0F80RaysQSZIkSdKaqfUaPCJiE2BbYGjHvMy8tR5BSZIkSZJ6r6YOXkScAnwcGAXMBvYE7gL2r1tkkiRJkqReqfUmKx8HJgJzM/NtwBuBZ+oVlCRJkiSp92rt4C3NzKUAEbF+Zv4Z2L5+YUmSJEmSeqvWa/DaI+JVwLXAbyLiaWBuvYKSJEmSJPVeTR28zHx3+fTsiLgF2Bj437pFJUmSJEnqtVqHaBIRu0fEx4BdgfbMfKl+YfWP0WPGEhE1PUaPGdvocCVJkiRpjdR6F82zgGOAX5SzfhQRV2Xm5LpF1g/a589jyo0P1VT2jIO8pFCSJEnSwFbrGbzjgYmZ+fnM/DzFzyS8v35hSVJrc4SBJEmqh1pvsvJ/FD9wvrScXh94rC4RSdIg4AgDSZJUD9128CLi20ACi4H7I+I35fSBwN31D0+SJEmSVKuezuDNKP/OBK6pmD+tLtFIkiRJkvqs2w5eZv6443lErAdsV04+lJnL6hmYJEmSJKl3arrJSkTsB/wFOB/4b+DhiNinhtcdEhEPRcSciPhMJ8vPiIgHIuK+iPhtRHgnAUmSJEnqo1rvovk14KDM3Dcz9wEOBr7e3Qsioo2iQ/gOYCfgvRGxU1Wxe4AJmbkrcDXwX70JXpIkSZK0Uq0dvCGZ+crt3jLzYWBID6+ZBMzJzEfKH0W/AjiiskBm3pKZ/ygnfw+MqjEeSZIkSVKVWn8mYWZE/AC4rJw+npU3YOnKVsD8iul2YI9uyp8M/LrGeCRJkiRJVWrt4H0Y+FfgY+X0bRTX4vWLiPhnYAKwbxfLTwNOAxgzZkx/rVaS1oi5SVKzMj9Jg1ePHbzyWrp7M3MHYEov6n4MGF0xPYpOfhw9It4OfA7YNzNf7KyizLwQuBBgwoQJ2YsYJKluzE2SmpX5SRq8erwGLzNXAA9FRG8P/0wHto2IrcufWDgOmFpZICLeCFwAHJ6ZT/SyfkmSJPWj0WPGEhE1PUaP8ebnUjOqdYjmJsD9EXE38HzHzMw8vKsXZObyiDgduAFoA36YmfdHxDnAjMycCnwFGA5cFREA87qrU5IkSfXTPn8eU258qOeCwBkHbV/naCT1Ra0dvP/Xl8oz83rg+qp5Z1U8f3tf6pUkSZIkra7bDl5EDKW4wcrrgT8CF2Xm8rURmCRJkiSpd3q6Bu/HFHe3/CPFD5Z/re4RSZIkSZL6pKchmjtl5i4AEXERcHf9Q5IkSZIk9UVPZ/CWdTxxaKYkSZIkNbeezuDtFhHPls8DGFZOB5CZuVFdo5MkSZIk1azbDl5mtq2tQCRJkiRJa6bHHzqXJEmSJA0MdvAkSZIkqUXYwZMkSZKkFmEHT5IkSZJahB08SZIkSWoRdvAkSZIkqUXYwZMkSZKkFmEHT5IkSZJahB08SZIkSWoRdvAkSZIkqUXYwZMkSZKkFmEHT5IkSZJahB08SZIkSWoRde3gRcQhEfFQRMyJiM90snyfiJgVEcsj4uh6xiJJkiRJra5uHbyIaAPOB94B7AS8NyJ2qio2DzgR+Em94pAkSZKkwWLdOtY9CZiTmY8ARMQVwBHAAx0FMvPRctnLdYxDkiRJkgaFeg7R3AqYXzHdXs6TJEmSJNXBgLjJSkScFhEzImLGwoULGx2OJAHmJknNy/wkDV71HKL5GDC6YnpUOa/XMvNC4EKACRMm5JqHJklrztwkNYlYh9j/szWXHQzMT9LgVc8O3nRg24jYmqJjdxzwvjquT1K92YiS1IzyZaZceFFNRc847eQ6ByNJjVW3Dl5mLo+I04EbgDbgh5l5f0ScA8zIzKkRMRG4BtgEOCwi/jMz31CvmCStIRtRkiRJTa2eZ/DIzOuB66vmnVXxfDrF0E1JkiRJ0hpyDJUkSZIktQg7eJIkSZLUIuzgSZIkSVKLsIMnSZIkSS3CDp4kSZIktQg7eJIkaRWjx4wlImp6jB4zttHhSpIq1PVnEqQ1MXrMWNrnz6up7KjRY5g/b26dI+pfrb59Uitr9f23ff48ptz4UE1lzzho+zpHI0nqDTt4alqt3sBo9e2TWpn7rySpWdnBkyRJkqR6iHWI/T9bc9n+YAdvAGv1IUKSJEnSgJYvM+XCi2oqesZpJ/fLKu3gDWAOEZLUrDwAJUlSY9jBkyT1Ow9ASZLUGP5MgiRJknov1vHnNKQm5Bk8SZIk9V6+7Jl6qQl5Bk+SJEmSWoQdPEmSJElqEXbwJEmS1FRGjxnr9X194Pu2dvTmfW4Er8GTJElSU6nXnXhb/SdcvIPxSvX8Xzf7+2wHT5IkSYNCrxrmB+9Y8xmYgdgZ7LgLai16u3316lz1pl6gqTth9VTXDl5EHAJ8E2gDfpCZX65avj5wCfAmYBFwbGY+Ws+YJEmSpB7V8S6hTXEmsY7bV68zXM1+5qxZ1K2DFxFtwPnAgUA7MD0ipmbmAxXFTgaezszXR8RxwHnAsfWKSZIkSWo0Oyqqp3reZGUSMCczH8nMl4ArgCOqyhwB/Lh8fjVwQDTqakRJkiTVRy9+FN2moLRm6jlEcytgfsV0O7BHV2Uyc3lELAY2BZ6sY1ySJElam3oxHBAG4FmrXlzPpibUYv+/yMz6VBxxNHBIZp5STr8f2CMzT68o86eyTHs5/deyzJNVdZ0GnFZObg/UmiE2o7U7i27fwOb2rTQ2M0fWM5h6WIPcBP7/Bzq3b+Dq7bYNtvzUyv97cPsGOrdvpS5zUz07eHsBZ2fmweX0vwNk5rkVZW4oy9wVEesCjwMjs5+CiogZmTmhP+pqRm7fwOb2DW6t/v64fQNbK29fK29bf2j198ftG9jcvtrU8xq86cC2EbF1RKwHHAdMrSozFTihfH40cHN/de4kSZIkabCp2zV45TV1pwM3UPxMwg8z8/6IOAeYkZlTgYuASyNiDvAURSdQkiRJktQHdf0dvMy8Hri+at5ZFc+XAsfUMYQL61h3M3D7Bja3b3Br9ffH7RvYWnn7Wnnb+kOrvz9u38Dm9tWgbtfgSZIkSZLWrnpegydJkiRJWovs4EmSJElSi7CDJ0mSJEktwg6eJEmSJLUIO3iSJEmS1CLs4EmSJElSi7CDJ0mSJEktwg6eJEmSJLUIO3jqUkT8OiJOWIPXnxsRn+jHkGpZ54kRcXvF9HMR8bpayvZzHIdFxJX1qFtS70XE+hHxQERsuZbXOy0iTimfHx8RN9ZStg5x/Dwi3lGPuqVmFBF3RMQb1/I6L46IyeXzt0bEQ7WUHUj6u+0UEXtHxF/K9tqR/VVvPQ2EfGoHr8WUO0jH4+WIeKFi+vje1JWZ78jMH/cxjpHAB4AL+vL6/pKZwzPzkTWtJyLOjojLerHeXwJviIhd13TdUiuKiEfL/LQkIp6JiDsj4sMRUa/vpdOAWzNzQZ3q71FmXp6ZB/VHXeX79/ZevOQ8YMA1JjXw9We7pKyvxwMhEXEYsCQz7+lz4GsoM2/LzO37o656HvxpAucA3ynba9c2OpgaNX0+tYPXYsodZHhmDgfmAYdVzLu8o1xErFvnUE4Ers/MF+q8nmb2U4pGpaTOHZaZI4CxwJeBTwMX1WldHwYurVPdTS8z7wY2iogJjY5Fg0ut7ZJ+Nqj392ZRY1tzLHB/HevvdwMhn9rBGyQiYr+IaI+IT0fE48CPImKTiPhVRCyMiKfL56MqXlM5tOjEiLg9Ir5alv1bD6en3wH8riqGIyJidkQ8GxF/jYhDyvkfjIgHyyP5j0TEhzqJ+8yIeCIiFkTEByuWbxoRU8s67wa2qVpnRsTrayz7zYiYXy6fGRFvLecfAnwWOLY84nhvOX/jiLiojOmxiJgcEW0VVU4D3tX9f0ZSZi7OzKnAscAJEbEzvDKs8qsRMS8i/h4R34uIYeWyByPi0I46ImLdMpftXl1/RIwBXgf8oWLesIj4WkTMjYjFZX7rqPuqiHi8nH9rRLyh4nUXR8T5EXFdmbP+EBHbVCw/MCL+XL72O0BULKseQt5d2W0i4uaIWBQRT0bE5RHxqnLZpcAY4JdlTvq3cv6eUZwJfSYi7o2I/areimmYk9QkImKdiPhM2R5YFBE/i4hXl8uGRsRl5fxnImJ6RGwREV8E3gp8p/zsf6eTetcD9qeiDRIRbRHx2XJdS8rv+NHlsk6/+8tlZ5dxXVK+7v6oaNRHxBsjYla57EpgaMWy/SKivcaym0QX7bGutjkidoiI30TEUxHxUET8Uzfv9QejTu2sqvWMi6LddXJEzANuLuefVK7/6Yi4ISLGlvP/SpGbO3LZ+tFN26rMoXdExNcjYhFwdnT/PdHTtnX3PTCg86kdvMHlNcCrKY6WnEbx//9ROT0GeAFYLVlW2AN4CNgM+C/gooiILsruUpYFICImAZcAnwJeBewDPFoufgI4FNgI+CDw9Vi1kfYaYGNgK+Bk4PyI2KRcdj6wFNgSOKl8dKWnstOB8RTv0U+AqyJiaGb+L/Al4MryiONuZfmLgeXA64E3AgcBlUMoHgTGRcRG3cQkqVQeFW2naMxAcVZvO4r98vUUOeCsctlPgfdWvPxg4MnMnNVJ1bsAj2Tm8op5XwXeBLyZYp//N+DlctmvgW2BzYFZQPVZhuOA/wQ2AeYAXwSIiM2AXwD/QZEn/wrs3dm21lA2gHOB1wI7AqOBswEy8/2seibkvyJiK+A6imFDrwY+Cfw8iuHyHR4EdkNqDh8FjgT2pficP03xPQ1wAsX3/mhgU4ozci9k5ueA24DTy8/+6Z3Uuy3wcma2V8w7gyJfvJOirXES8I9yWaff/RWvPRy4gqLtMpWynVR2JK+lOFP4auAq4KjONrSGsl22xzrb5ojYEPhNGe/mFDnpvyNip87Wz9prZ3XYlyJvHRwRR1AcJH8PMLLclp+W27YNq+ayF+m5bbUH8AiwBUXu7e57oqdt6/R7oCXyaWb6aNEHRQfq7eXz/YCXgKHdlB8PPF0xPQ04pXx+IjCnYtkGQAKv6aKuZcAOFdMXAF+vMe5rgY9XxP0CsG7F8ieAPYG2TtbzJeD2iumk2OF7LNtJHE8Du5XPzwYuq1i2BfAiMKxi3nuBWyqmh5TrH9Poz4IPH832qMxPVfN/D3yOooPzPLBNxbK9gL+Vz18PLAE2KKcvB87qYl3HA7+vmF6nzCu71RDnq8r9eONy+mLgBxXL3wn8uXz+gar1BEWHtTKP3l5L2U7iOBK4p6v3j2J466VVr7kBOKFi+lTg5kb/730M3gertkseBA6oWLZl+T29LkUn4k5g107qmNbVflIu3xt4vGreQ8ARNcZY/d1/U8WynSg6mlAcqP4/ICqW3wlMLp/vB7TXUraTGMbTRXusnD4WuK3qNRcAn69xG6+ln9pZVfWOo8iXr6uY92vg5IrpdSg612M7+Ux027aiyKHzKpb19D3R3bZ1+T1AC+TThoxdVcMszMylHRMRsQHwdeAQiiPRACMioi0zV3Ty+sc7nmTmP8qTd8O7WNfTwIiK6dHA9Z0VjGKo5+cpjsCsQ9F5/GNFkUW56pH3f5TrHUnxRTC/YtncLuLpsWxEfJLi6M5rKRLURhRH1jszlqIDt6DiJOY6VfV3bP8zXdQhaXVbAU9R7LMbADMr9rGgaHCQmXMi4kHgsIj4JcVR9q7umFedjzajGB711+qC5VCgLwLHlDG8XPGaxeXzxyte0pGPoMgdr+SAzMyIqMwJlbotGxFbAN+kOJs5giK/PN1FXVDkpGOiuLlEhyHALRXTIzAfqXmMBa6JiJcr5q2gaORfStFuuCKKocmXAZ/LzGU11Fu9v1PWtdr+DjV991fv70OjuPbrtcBjWbb2S121Qbot24f22Fhgj4h4pmLeunRx3eFaamdVqiw/FvhmRHytMiSKXF9dVy1tq8rn3X5PlLrati6/B2iBfOoQzcElq6bPBLYH9sjMjSiOMEHFdSBr4D6KRNJhPp2M246I9YGfU5wm3yIzX0XREawlhoUUp/FHV8wb05eyUYy5/zfgn4BNyjgWV8RR/d7NpzjKtFlmvqp8bJSZb6gosyPwaGY+W8O2SINeREyk+NK/HXiS4ujqGyr2sY2zuFFDh45hmkcAD2TmnC6qvg/YOlZekP8kxZCjzq4leV9Z39sphvWM6wivhk1YQEWOKYewj+5j2S9R5J1dyvz8z1UxdJaTLq14r16VmRtm5pcryuwI3FvDdkhrw3zgHVWf2aGZ+VhmLsvM/8zMnSiGzx1KcdYbVv/sV5tDsUttVbWuztogPX33d2cBsFXVpSpdtUF6KttTe6yz/f13Ve/d8Mz8SPWK12I7q1JlvPOBD1XFOiwz7+zkdbW0rSrrruV7oivdfQ8M+HxqB29wG0GxYzwTxYXNn+/Huq+nGIPd4SLggxFxQBQXVm8VETsA6wHrUyaR8ihTTbcRL49q/YLiItsNyrHnJ/Sx7AiKJLYQWDcizqI4itfh7xTX061T1rcAuBH4WkRsVG7TNhFRuc37UgxNkNSNch86lOI6l8sy84+Z+TLwfYprRTYvy20VEQdXvPQKinzxEYprUTqVxbU4c4BJ5fTLwA+BKRHx2ihuwLBX2RAaQdHAWERxZPhLvdiU6yh+HuU9ZWfyYxTXf/Sl7AjgOWBx2VD9VNXr/05xc4IOl1GczTy43J6h5Q0GRlWUMSepmXwP+GKsvOHGyPJ6LSLibRGxS3lG/VmKYYIdZ/qqP/uryMyXgJtYtQ3yA+ALEbFtFHaNiE3p+bu/O3eVr/1YRAyJiPdQ5pg+lO2pPVa9zb8CtouI95f1DYmIiRGxYyfrXivtrG58D/j3KG9WFcVNVI7pYn21tK0qy9fyPdHVtnX3PTDg86kdvMHtG8AwiqMYvwf+tx/rvgR4Z5R3I8ri5gkfpBiCsJji7lZjM3MJRcPmZxTDKt5HcRFzrU6nONX+OMW1MT/qY9kbKLb/YYohA0tZdRjAVeXfRRHRcROHD1AkzgfK2K+muIagw3tp8O8ASk3ulxGxhGJf+xwwhSJPdPg0Rcfs9xHxLEWj7ZXflSobA3dRHOG/sod1XQC8v2L6kxRDlKZTDAk9j+I78RKKHPAYxb79+1o3JjOfpBja+WWKDuK2wB19LPufwO4U+fI6ikZWpXOB/4jiDm+fzMz5FGceP0vRkJtP0SlcB145O/pcmYulZvBNiu/7G8s88HuKG2hAcbDjaorO3YMUbYZLK153dBR3ZPxWF3VX7+9TKNoZN5Z1XkTR/unpu79LZUfyPRTXhT1FcV1c9X5aa9lv0H17bJVtLttOB1HcXOX/KNo151F05KrXvTbbWavJzGvK2K4o8/ifKO603pWe2lbVuv2e6EGn3wOtkE9j1eHAUv+JiC8BT2TmNxody9pWjtt+f2Z2edtiSWtPeVT2HoqbOjTsx84bJSJ+DlyUmZ1eCy21moi4g+LOk/c0Oha1loGQT+3gSZIkSVKLcIimJEmSJLUIO3iSJEmS1CLs4EmSJElSi7CDJ0mSJEktYt2eizSXzTbbLMeNG9foMCT1o5kzZz6ZmSMbHceaMDdJrcn8JKkZdZebBlwHb9y4ccyYMaPRYUjqRxExt9ExrClzk9SazE+SmlF3uckhmpIkSZLUIuzgSZIkSVKLqGsHLyIOiYiHImJORHymk+UnRsTCiJhdPk6pZzySJEmS1Mrqdg1eRLQB5wMHAu3A9IiYmpkPVBW9MjNPr1ccUiMtW7aM9vZ2li5d2uhQmsLQoUMZNWoUQ4YMaXQo0qBnflqV+UlqDuamVfUlN9XzJiuTgDmZ+QhARFwBHAFUd/CkltXe3s6IESMYN24cEdHocBoqM1m0aBHt7e1svfXWjQ5HGvTMTyuZn6TmYW5aqa+5qZ5DNLcC5ldMt5fzqh0VEfdFxNURMbqziiLitIiYEREzFi5cWI9YpbpYunQpm2666aBPUAARwaabbtpSR+TMTRrIzE8rmZ+k5mFuWqmvuanRN1n5JTAuM3cFfgP8uLNCmXlhZk7IzAkjRw7on6LRIGSCWqnV3gtzkwa6Vtsn10SrvRfmJw1krbY/rom+vBf17OA9BlSekRtVzntFZi7KzBfLyR8Ab6pjPJIkSZLU0urZwZsObBsRW0fEesBxwNTKAhGxZcXk4cCDdYxHagpvfvOb61b3VVddxY477sjb3va2uq1DUusyP0lqRuam3qnbTVYyc3lEnA7cALQBP8zM+yPiHGBGZk4FPhYRhwPLgaeAE+sVj9Qs7rzzzjV6/YoVK2hra+t02UUXXcT3v/993vKWt9RU1/Lly1l33Xrea0nSQGJ+ktSMzE29U9dr8DLz+szcLjO3ycwvlvPOKjt3ZOa/Z+YbMnO3zHxbZv65nvFIzWD48OEALFiwgH322Yfx48ez8847c9ttt3X7mjPPPJPddtuNu+66i8suu4xJkyYxfvx4PvShD7FixQrOOeccbr/9dk4++WQ+9alPsWLFCj71qU8xceJEdt11Vy644AIApk2bxlvf+lYOP/xwdtppp27L7bfffhx99NHssMMOHH/88WQmANOnT+fNb34zu+22G5MmTWLJkiVd1iNp4DA/SWpG5qZeyswB9XjTm96U0kDxwAMPrDZvww03zMzMr371qzl58uTMzFy+fHk+++yzXdYD5JVXXvlKnYceemi+9NJLmZn5kY98JH/84x9nZua+++6b06dPz8zMCy64IL/whS9kZubSpUvzTW96Uz7yyCN5yy235AYbbJCPPPJIj+U22mijnD9/fq5YsSL33HPPvO222/LFF1/MrbfeOu++++7MzFy8eHEuW7asy3pqeU8ozuo3PL+syaO3uWnU6DEJ1PQYNXpMr+qWamF+Mj9JzcjctOa5qbnPL0otbOLEiZx00kksW7aMI488kvHjx3dZtq2tjaOOOgqA3/72t8ycOZOJEycC8MILL7D55puv9pobb7yR++67j6uvvhqAxYsX85e//IX11luPSZMmvfJ7Kj2VGzVqFADjx4/n0UcfZeONN2bLLbd8Zf0bbbRRt/X4m1Kda58/jyk3PlRT2TMO2r7O0UirMj9Jakbmptq0dAdv9JixtM+fV1PZUaPHMH/e3DpHJK20zz77cOutt3Lddddx4okncsYZZ/CBD3yg07JDhw59Zex4ZnLCCSdw7rnndlt/ZvLtb3+bgw8+eJX506ZNY8MNN6yp3Prrr//KdFtbG8uXL+/1+iQNPOYnSc3I3FSbRv8OXl11HCGv5VFrR1DqL3PnzmWLLbbg1FNP5ZRTTmHWrFk1ve6AAw7g6quv5oknngDgqaeeYu7c1Q9OHHzwwXz3u99l2bJlADz88MM8//zzfS7XYfvtt2fBggVMnz4dgCVLlrB8+fJe1yOpeZmfJDUjc1NtWvoMntTMpk2bxle+8hWGDBnC8OHDueSSS2p63U477cTkyZM56KCDePnllxkyZAjnn38+Y8eOXaXcKaecwqOPPsruu+9OZjJy5Eiuvfba1eqrtVyH9dZbjyuvvJKPfvSjvPDCCwwbNoybbrqp1/VIal7mJ0nNyNxUmyiu0Rs4JkyYkDNmzKipbET06hqXgfZeqPk9+OCD7Ljjjo0Oo6l09p5ExMzMnNCgkPpFb3ITmJ/UeOan1ZmfpMYzN62ut7mppYdoSpIkSdJg4hBNqYnssccevPjii6vMu/TSS9lll10aFJEkFcxPkpqRuWl1dvCkJvKHP/yh0SFIUqfMT5KakblpdQ7RlCRJkqQWYQdPkiRJklqEHTxJkiRJahF28KQGGj1mLBHRb4/RY8b2uM62tjbGjx//yuPRRx/tsuzw4cP7cWslDSTmJ0nNyNzUM2+yIjVQ+/x5Nf8WWi3OOGj7HssMGzaM2bNn99s6JbUm85OkZmRu6pln8KRB7rnnnuOAAw5g9913Z5ddduF//ud/ViuzYMEC9tlnH8aPH8/OO+/MbbfdBsCNN97IXnvtxe67784xxxzDc889t7bDl9TCzE+SmlGz5yY7eNIg88ILL7wyxODd7343Q4cO5ZprrmHWrFnccsstnHnmmWTmKq/5yU9+wsEHH8zs2bO59957GT9+PE8++SSTJ0/mpptuYtasWUyYMIEpU6Y0aKsktQLzk6RmNNByk0M0pUGmepjBsmXL+OxnP8utt97KOuusw2OPPcbf//53XvOa17xSZuLEiZx00kksW7aMI488kvHjx/O73/2OBx54gL333huAl156ib322mttb46kFmJ+ktSMBlpusoMnDXKXX345CxcuZObMmQwZMoRx48axdOnSVcrss88+3HrrrVx33XWceOKJnHHGGWyyySYceOCB/PSnP21Q5JJanflJUjNq9tzkEE1pkFu8eDGbb745Q4YM4ZZbbmHu3LmrlZk7dy5bbLEFp556KqeccgqzZs1izz335I477mDOnDkAPP/88zz88MNrO3xJLcz8JKkZNXtuqusZvIg4BPgm0Ab8IDO/3EW5o4CrgYmZOaOeMUnNZNToMTXdvak39fXW8ccfz2GHHcYuu+zChAkT2GGHHVYrM23aNL7yla8wZMgQhg8fziWXXMLIkSO5+OKLee9738uLL74IwOTJk9luu+3WeDskNZ75SVIzMjf1LKovCOy3iiPagIeBA4F2YDrw3sx8oKrcCOA6YD3g9J46eBMmTMgZM2rrA0ZEzbdRPeOg7Ve7OFJaUw8++CA77rhjo8NoKp29JxExMzMnNCikftGb3ATmJzWe+Wl15iep8cxNq+ttbqrnEM1JwJzMfCQzXwKuAI7opNwXgPOApZ0skyRJkiTVqJ4dvK2A+RXT7eW8V0TE7sDozLyujnFIkiRJ0qDQsJusRMQ6wBTgzBrKnhYRMyJixsKFC+sfnNSPHFq3Uqu9F+YmDXSttk+uiVZ7L8xPGshabX9cE315L+rZwXsMGF0xPaqc12EEsDMwLSIeBfYEpkbEamNJM/PCzJyQmRNGjhxZx5Cl/jV06FAWLVpkoqJIUIsWLWLo0KGNDqXfmJs0kJmfVjI/Sc3D3LRSX3NTPe+iOR3YNiK2pujYHQe8r2NhZi4GNuuYjohpwCe9i6ZayahRo2hvb8ejp4WhQ4cyatSoRochCfNTNfOT1BzMTavqS26qWwcvM5dHxOnADRQ/k/DDzLw/Is4BZmTm1HqtW2oWQ4YMYeutt250GJK0GvOTOjN6zFja58+rqeyo0WOYP2/13/+S1oS5ac3V9XfwMvN64PqqeWd1UXa/esYiSZKk7rXPn9ern3CR1HwadpMVSZIkSVL/soMnSZIkSS3CDp4kSZIktQg7eJIkSZLUIuzgSZIkSVKLsIMnSZIkSS3CDp4kSZIktQg7eJIkSZLUIuzgSZIkSVKLqKmDFxGHRYSdQUmSJElqYrV22o4F/hIR/xURO9QzIEmSJElS39TUwcvMfwbeCPwVuDgi7oqI0yJiRF2jkyRJkiTVrOZhl5n5LHA1cAWwJfBuYFZEfLROsUmSJEmSeqHWa/COiIhrgGnAEGBSZr4D2A04s37hSZIkSZJqtW6N5d4DfD0zb62cmZn/iIiT+z8sSZIkSVJv1TpE8/Hqzl1EnAeQmb/t96gkSZIkSb1WawfvwE7mvaM/A5EkSZIkrZluh2hGxEeAfwG2iYj7KhaNAO6oZ2CSJEmSpN7p6Rq8nwC/Bs4FPlMxf0lmPlW3qCRJkiRJvdbTEM3MzEeBfwWWVDyIiFf3VHlEHBIRD0XEnIj4TCfLPxwRf4yI2RFxe0Ts1PtNkCRJkiRBbWfwDgVmAglExbIEXtfVCyOiDTif4vq9dmB6REzNzAcq68/M75XlDwemAIf0diMkSZIkST108DLz0PLv1n2oexIwJzMfAYiIK4AjgFc6eOWPp3fYkKLTKEmSJEnqg55usrJ7d8szc1Y3i7cC5ldMtwN7dLKOfwXOANYD9u9ufZIkSZKkrvU0RPNr3SxL+qFDlpnnA+dHxPuA/wBOqC4TEacBpwGMGTNmTVcpSf3C3CSpWZmfpMGrpyGab1uDuh8DRldMjyrndeUK4LtdxHEhcCHAhAkTHMYpqSmYmyQ1K/OTNHj1NERz/8y8OSLe09nyzPxFNy+fDmwbEVtTdOyOA95XVf+2mfmXcvJdwF+QJEmSJPVJT0M09wVuBg7rZFkCXXbwMnN5RJwO3AC0AT/MzPsj4hxgRmZOBU6PiLcDy4Cn6WR4piRJkiSpNj0N0fx8+feDfak8M68Hrq+ad1bF84/3pV5JkiRJ0up6+qFzACJi04j4VkTMioiZEfHNiNi03sFJkiRJkmpXUweP4gYoC4GjgKPL51fWKyhJkiRJUu/1dA1ehy0z8wsV05Mj4th6BCRJkiRJ6ptaz+DdGBHHRcQ65eOfKG6eIkmSJElqEj39TMISirtlBvAJ4LJy0TrAc8An6xmcJEmSJKl2Pd1Fc8TaCkSSJEmStGZqvQaPiNgE2BYY2jEvM2+tR1CSJEmSpN6rqYMXEacAHwdGAbOBPYG7gP3rFpkkSZIkqVdqvcnKx4GJwNzMfBvwRuCZegUlSZIkSeq9Wjt4SzNzKUBErJ+Zfwa2r19YkiRJkqTeqvUavPaIeBVwLfCbiHgamFuvoCRJkiRJvVdTBy8z310+PTsibgE2Bv63blFJkiRJknqtN3fR3B14C8Xv4t2RmS/VLSpJkiRJUq/VdA1eRJwF/BjYFNgM+FFE/Ec9A5MkSZIk9U6tZ/COB3aruNHKlyl+LmFyneKSJEmSJPVSrXfR/D8qfuAcWB94rP/DkSRJkiT1Vbdn8CLi2xTX3C0G7o+I35TTBwJ31z88SZIkSVKtehqiOaP8OxO4pmL+tLpEI0mSJEnqs247eJn5447nEbEesF05+VBmLqtnYJIkSZKk3qn1Lpr7AX8Bzgf+G3g4Ivap4XWHRMRDETEnIj7TyfIzIuKBiLgvIn4bEWN7F74kSZIkqUOtN1n5GnBQZu6bmfsABwNf7+4FEdFG0SF8B7AT8N6I2Kmq2D3AhMzcFbga+K/eBC9JkiRJWqnWDt6QzHyoYyIzHwaG9PCaScCczHyk/FH0K4AjKgtk5i2Z+Y9y8vfAqBrjkSRJkiRVqfV38GZGxA+Ay8rp41l5A5aubAXMr5huB/bopvzJwK9rjEeSJEmSVKXWDt6HgX8FPlZO30ZxLV6/iIh/BiYA+3ax/DTgNIAxY8b012olaY2YmyQ1K/OTNHj12MErr6W7NzN3AKb0ou7HgNEV06Po5MfRI+LtwOeAfTPzxc4qyswLgQsBJkyYkL2IQZLqxtwkqVmZn6TBq8dr8DJzBfBQRPT28M90YNuI2Lr8iYXjgKmVBSLijcAFwOGZ+UQv65ckSZIkVah1iOYmwP0RcTfwfMfMzDy8qxdk5vKIOB24AWgDfpiZ90fEOcCMzJwKfAUYDlwVEQDzuqtTkiRJktS1Wjt4/68vlWfm9cD1VfPOqnj+9r7UK6kxRo8ZS/v8eTWVHTV6DPPnza1zRJJkbpKkSt128CJiKMUNVl4P/BG4KDOXr43AJDWf9vnzmHLjQz0XBM44aPs6RyNJBXOTJK3U0zV4P6a4u+UfKX6w/Gt1j0iSJEmS1Cc9DdHcKTN3AYiIi4C76x+SJEmSJKkvejqDt6zjiUMzJUmSJKm59XQGb7eIeLZ8HsCwcjqAzMyN6hqdJEmSJKlm3XbwMrNtbQUiSZIkSVozPf7QuSRJkiRpYLCDJ0mSJEktwg6eJEmSJLUIO3iSJEmS1CLs4EmSJElSi7CDJ0mSJEktwg6eJEmSJLUIO3iSJEmS1CLs4EmSJElSi7CDJ0mSJEktwg6e1CCjx4wlImp6jB4zttHhShpEzE+SNHCt2+gApK6MHjOW9vnzaio7avQY5s+bW+eI+lf7/HlMufGhmsqecdD2dY5GklYyP0nSwGUHT03LBoYkSZLUO3UdohkRh0TEQxExJyI+08nyfSJiVkQsj4ij6xmLJEmSJLW6unXwIqINOB94B7AT8N6I2Kmq2DzgROAn9YpDkqT+5jVqkqRmVc8hmpOAOZn5CEBEXAEcATzQUSAzHy2XvVzHOCRJ6lcOIZck1aIR95SoZwdvK2B+xXQ7sEcd1ydJahKtfpMkSZJq0YgDggPiJisRcRpwGsCYMWMaHE3zsAElNZa5qWue4ZIay/wkDV717OA9BoyumB5Vzuu1zLwQuBBgwoQJueahtQYbUFJjmZskNSvzkzR41fMumtOBbSNi64hYDzgOmFrH9UmSJEnSoFa3Dl5mLgdOB24AHgR+lpn3R8Q5EXE4QERMjIh24Bjggoi4v17xSJIkSVKrq+s1eJl5PXB91byzKp5Ppxi6KUmSJElaQ3X9oXNJkiS1qFjH34OUmtCAuIumJEmSmky+7M3epCbkGTxJkiRJahF28CRJkiSpRdjBkyRJkqQWYQdPkiRJklqEHTxJkiRJahF28CRJkiSpRdjBkyRJUlMZPWasv7GnptWbz2cj+Dt4kiRJairt8+f5G3t9MHrMWNrnz6up7KjRY5g/b26dI2pNzf75tIMnSZKkQaHVO0DN3vHQ2mEHT5IkSYOCHaDBo9U7892xgydJkiSppQzmzrw3WZEkSZLU9Jr95ibNwjN4kiRJUrVYp+aOwoAc4lfH7avX8MjBfFauN+zgSZIkSdXy5bp1Jpri+rA6bp8dscaygydJkiStRXaAVE9egydJkiRJLcIOniRJkiS1iLp28CLikIh4KCLmRMRnOlm+fkRcWS7/Q0SMq2c8kiRJaoDyhh7eAVGqv7pdgxcRbcD5wIFAOzA9IqZm5gMVxU4Gns7M10fEccB5wLH1ikmSJEkN0IsbeoDXnUlrop5n8CYBczLzkcx8CbgCOKKqzBHAj8vnVwMHhIdtJEmSJKlP6nkXza2A+RXT7cAeXZXJzOURsRjYFHiyjnFJkiRJ/acXvyk3ILl9A0pkZn0qjjgaOCQzTymn3w/skZmnV5T5U1mmvZz+a1nmyaq6TgNOKye3B2o9x78Zrd1ZdPsGNrdvpbGZObKewdTDGuQm8P8/0Ll9A1dvt22w5adW/t+D2zfQuX0rdZmb6tnB2ws4OzMPLqf/HSAzz60oc0NZ5q6IWBd4HBiZ/RRURMzIzAn9UVczcvsGNrdvcGv198ftG9haeftaedv6Q6u/P27fwOb21aae1+BNB7aNiK0jYj3gOGBqVZmpwAnl86OBm/urcydJkiRJg03drsErr6k7HbgBaAN+mJn3R8Q5wIzMnApcBFwaEXOApyg6gZIkSZKkPqjnTVbIzOuB66vmnVXxfClwTB1DuLCOdTcDt29gc/sGt1Z/f9y+ga2Vt6+Vt60/tPr74/YNbG5fDep2DZ4kSZIkae2q5zV4kiRJkqS1qCU7eBHxw4h4ovwZhpYTEaMj4paIeCAi7o+Ijzc6pv4UEUMj4u6IuLfcvv9sdEz9LSLaIuKeiPhVo2Oph4h4NCL+GBGzI2JGo+NpJq2cn8xNraGV85O5qWutnJvA/NQKWjk3Qf/mp5YcohkR+wDPAZdk5s6Njqe/RcSWwJaZOSsiRgAzgSMz84EGh9YvovilyQ0z87mIGALcDnw8M3/f4ND6TUScAUwANsrMQxsdT3+LiEeBCdW/aanWzk/mptbQyvnJ3NS1Vs5NYH5qBa2cm6B/81NLnsHLzFsp7srZkjJzQWbOKp8vAR4EtmpsVP0nC8+Vk0PKR8sciYiIUcC7gB80Ohatfa2cn8xNA5/5afBq5dwE5qeBztzUOy3ZwRtMImIc8EbgDw0OpV+Vp+FnA08Av8nMVtq+bwD/Brzc4DjqKYEbI2JmRJzW6GC09pmbBqxv0Nr5ydwk89PA9A1aOzdBP+YnO3gDWEQMB34OfCIzn210PP0pM1dk5nhgFDApIlpiuEhEHAo8kZkzGx1Lnb0lM3cH3gH8azn0R4OEuWlgGiT5ydw0yJmfBp5BkpugH/OTHbwBqhxf/XPg8sz8RaPjqZfMfAa4BTikwaH0l72Bw8tx1lcA+0fEZY0Nqf9l5mPl3yeAa4BJjY1Ia4u5aUBr+fxkbhrczE8DVsvnJujf/GQHbwAqL6S9CHgwM6c0Op7+FhEjI+JV5fNhwIHAnxsaVD/JzH/PzFGZOQ44Drg5M/+5wWH1q4jYsLyAnYjYEDgIaMm7smlV5qaBrdXzk7lpcDM/DVytnpug//NTS3bwIuKnwF3A9hHRHhEnNzqmfrY38H6KIxizy8c7Gx1UP9oSuCUi7gOmU4wjb8lb4raoLYDbI+Je4G7gusz83wbH1DRaPD+Zm9TMzE3daPHcBOYnNbd+zU8t+TMJkiRJkjQYteQZPEmSJEkajOzgSZIkSVKLsIMnSZIkSS3CDp4kSZIktQg7eJIkSZLUIuzgqelFxKsi4l8aHYckVTI3SWpW5qfBzQ6e6i4i1u1uugavAkxSkvqVuUlSszI/aU309sOiQS4iPgB8EkjgPuD/AT8ENgMWAh/MzHkRcTGwFHgjcEdEvLpq+nzgfGAk8A/g1Mz8c0RsAXwPeF25yo8AHwO2iYjZwG+A64CzgSeBnYGZwD9nZkbEm4ApwPBy+YmZuSAiPgZ8GFgOPJCZx0XEvsA3y/UksE9mLunnt0zSWmBuktSszE9a6zLTh4+aHsAbgIeBzcrpVwO/BE4op08Cri2fXwz8CmjrYvq3wLbl8z2Am8vnVwKfKJ+3ARsD44A/VcSxH7AYGEVxFvou4C3AEOBOYGRZ7ljgh+Xz/wPWL5+/qvz7S2Dv8vlwYN1Gv8c+fPjo/cPc5MOHj2Z9mJ98NOLhGTz1xv7AVZn5JEBmPhURewHvKZdfCvxXRfmrMnNF9XREDAfeDFwVER3L1q9YxwfK+lcAiyNik05iuTsz2wHKo1PjgGcojkr9pqy3DVhQlr8PuDwirgWuLefdAUyJiMuBX3TUJ2nAMTdJalbmJ611dvBUT893Mb0O8Exmjl+Dul+seL6C4rMcwP2ZuVcn5d8F7AMcBnwuInbJzC9HxHXAOymGPhycmX9eg5gkDQzmJknNyvykNeZNVtQbNwPHRMSmAOXY8DuB48rlxwO39VRJZj4L/C0ijinriYjYrVz8W4qx40REW0RsDCwBRtQQ30PAyPLIGBExJCLeEBHrAKMz8xbg0xRDF4ZHxDaZ+cfMPA+YDuxQwzokNR9zk6RmZX7SWmcHTzXLzPuBLwK/i4h7KS7I/SjwwYi4D3g/8PEaqzseOLms537giHL+x4G3RcQfKS4A3ikzF1EcJfpTRHylm/heAo4GzivrnU0xnKENuKys8x7gW5n5DPCJss77gGXAr2uMXVITMTdJalbmJzVCZHGRpCRJkiRpgPMMniRJkiS1CDt4kiRJktQi7OBJkiRJUouwgydJkiRJLcIOniRJkiS1CDt4kiRJktQi7OBJkiRJUouwgydJkiRJLeL/B6Hmklj9eVrvAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x432 with 6 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(2, 3, sharex=True, sharey=True, figsize=(15, 6))\n",
+    "hist_kwargs = {\"x\":\"correctness\", \"bins\": 20, \"stat\": \"probability\", \"hue\": \"is_reference\"}\n",
+    "\n",
+    "ax = axes[0, 0]\n",
+    "ax.set_title(\"Train (candidate and reference)\")\n",
+    "sns.histplot(train_data, ax=ax, **hist_kwargs);\n",
+    "\n",
+    "ax = axes[0, 1]\n",
+    "ax.set_title(\"Dev (candidate and reference)\")\n",
+    "sns.histplot(dev_data, ax=ax, **hist_kwargs);\n",
+    "\n",
+    "ax = axes[0, 2]\n",
+    "ax.set_title(\"Test (candidate and reference)\")\n",
+    "sns.histplot(test_data, ax=ax, **hist_kwargs);\n",
+    "\n",
+    "ax = axes[1, 0]\n",
+    "ax.set_title(\"Train (candidate)\")\n",
+    "sns.histplot(train_cand_data, ax=ax, **hist_kwargs);\n",
+    "\n",
+    "ax = axes[1, 1]\n",
+    "ax.set_title(\"Dev (candidate)\")\n",
+    "sns.histplot(dev_cand_data, ax=ax, **hist_kwargs);\n",
+    "\n",
+    "ax = axes[1, 2]\n",
+    "ax.set_title(\"Test (candidate and reference)\")\n",
+    "sns.histplot(test_cand_data, ax=ax, **hist_kwargs);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "eedbb762",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/kat/miniconda3/envs/eqqa-env/lib/python3.9/site-packages/seaborn/distributions.py:461: FutureWarning: In a future version, the Index constructor will not infer numeric dtypes when passed object-dtype sequences (matching Series behavior)\n",
+      "  pd.Index(edges, name=\"edges\"),\n",
+      "/home/kat/miniconda3/envs/eqqa-env/lib/python3.9/site-packages/seaborn/distributions.py:462: FutureWarning: In a future version, the Index constructor will not infer numeric dtypes when passed object-dtype sequences (matching Series behavior)\n",
+      "  pd.Index(widths, name=\"widths\"),\n",
+      "/home/kat/miniconda3/envs/eqqa-env/lib/python3.9/site-packages/seaborn/distributions.py:461: FutureWarning: In a future version, the Index constructor will not infer numeric dtypes when passed object-dtype sequences (matching Series behavior)\n",
+      "  pd.Index(edges, name=\"edges\"),\n",
+      "/home/kat/miniconda3/envs/eqqa-env/lib/python3.9/site-packages/seaborn/distributions.py:462: FutureWarning: In a future version, the Index constructor will not infer numeric dtypes when passed object-dtype sequences (matching Series behavior)\n",
+      "  pd.Index(widths, name=\"widths\"),\n",
+      "/home/kat/miniconda3/envs/eqqa-env/lib/python3.9/site-packages/seaborn/distributions.py:461: FutureWarning: In a future version, the Index constructor will not infer numeric dtypes when passed object-dtype sequences (matching Series behavior)\n",
+      "  pd.Index(edges, name=\"edges\"),\n",
+      "/home/kat/miniconda3/envs/eqqa-env/lib/python3.9/site-packages/seaborn/distributions.py:462: FutureWarning: In a future version, the Index constructor will not infer numeric dtypes when passed object-dtype sequences (matching Series behavior)\n",
+      "  pd.Index(widths, name=\"widths\"),\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3gAAAGECAYAAABkoYIFAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAApMUlEQVR4nO3debhlZXkn7N9DlSBqOVJJE0BAxUTUGE2J2p0oUWPAAUzUdoxiMIgtDl+0I3b8iE00xiRqTId0nIc4IJrWD1sMpqM0cUAoFAdAkhKHAkVLRcQZ9P3+WOskm5Mz7FNV65yzV933de2r9lrr3Ws/e3pq//YaTrXWAgAAwOzba60LAAAAYPcQ8AAAAEZCwAMAABgJAQ8AAGAkBDwAAICREPAAAABGQsBbRVX1/qp60i7c/iVV9ezdWNI093lcVX14Yvq7VXW7acbOiqo6pKpaVW3cTev72ao6t6quraqX7Y51Dq2qnlFVL13rOpgdVbVPVV1SVfuv8v2eU1VP6a8/vqo+MM3YWVJVL6yqt+zG9f1mVW3v+/fdd9d6h1RV51fVnde6DoBZJOAto/8Pce7y06r6wcT041eyrtba0a21N+1kHZuTPDHJq3bm9rtLa+1mrbXLd3U9u/sLzDpzQpJvJLl5a+05a13MlF6T5PFV9TNrXQg7p6q+2Pena6vq21X10ao6saqG6vMnJDm3tfbVgda/rNbaW1trD9od6+qfvwfujnWtQ3+e5KS+f39yrYuZ0p8nOXWtiwCYRQLeMvr/EG/WWrtZki8nedjEvLfOjdtdW3+WcFySs1prPxj4fljClK/zwUkuaa21gda/27XWfpjk/el+RGB2Pay1tinde/BPkjwvyesGuq8Tk/ztQOtmSivoSRcPuP4hnJnk16rqP6zR/QPMLAFvJ1XVkVV1RVU9r6quSvKGqrpVVf3vqtpRVVf31w+cuM3krkXHVdWHq+rP+7FfqKqjl7jLo5P833k1HFtVF1XVd6rq81V1VD//yVV1af9L/uVV9dQF6n5OVX29qr5aVU+eWH6bqjqzX+f5SW4/7z5bVd1hyrGv7HcL+k5VXVhVv9rPPyrJf0vy6H5L6Kf6+beoqtf1NV1ZVS+qqg2LPP9HVNXH+i0VX62qv6qqvefVeWJV/Us/5rSqqn7Zhv55/0ZVXZ7kIUs873O/7D+vqj6d5HtVtbGq7t1vIfl2VX2qqo7sx74xyZOS/H7/2B5YVXtV1cn9a/TNqjqjqm7dj5/bPfT4qvpykg/283+nfw2vrqqzq+rgaR5bv/x3J17/S6rqHv38n6uqv+vfn1+oqmfOe6jnLPdcMBtaa9e01s5M8ugkT6qquyT/ulvln1fVl6vqa1X1N1W1b7/s0qp66Nw6+vf5jrn3z6Squm2S2yX5+MS8favqZVX1paq6pu9vc+t+Z1Vd1c8/tyZ2vauqN/bv4ff179mPV9XtJ5b/elV9rr/tXyWZfK/P34V8qbG3r6oP9p/Bb1TVW6vqlv2yv01y2yTv7T+3v9/PX/BzvpCJz/jc5+4359dZi/T7qjq0qv5vf9t/SLLfEvez0P89C/aY/vX+bpINST5VVZ/v17FoL6hu74p3VdVbquo7SY6rJXrzFI/t1lX1hqr6Sr/8PRPLHlrd/2FzW5x/cW5Z/6PThUl+Y7HnAoBFtNZcprwk+WKSB/bXj0xyfZKXJtknyb5JbpPkEUlukmRTkncmec/E7c9J8pT++nFJrkvyu+n+831akq8kqUXue0eSe05MH5HkmiS/ni6oH5DkF/plD0kXtirJ/ZJ8P8k95tV9apIbJXlwv/xW/fLTk5yR5KZJ7pLkyiQfnrjfluQOU459Qv+cbEzynCRXJblxv+yFSd4y7zG+O90uqDdN8jNJzk/y1EWej19Ocu9+3YckuTTJs+fV+b+T3DLdF7cdSY7ql52Y5HNJDkpy6yQf6sdvXOJ1v6gfv2//XH+zf+726l+DbybZ3I9/Y5IXTdz+WUnOS3Jg/155VZK398sO6e/7zf3j3jfJsUm2JblT//hekOSjUz62R/Wvwz371/8O6X693yvdl6VTkuyd7sv55Ul+Y2K990jyrbX+nLns3CUT/Wne/C8neVp//RXptozcOl2Pem+Sl/TLTkny1onbPSTJpYvc10OSXDxv3mnpetwB6Xraf0yyT7/sd/r72yfJXyS5aOJ2b+w/P0f07/e3Jjm9X7ZfkmuTPDJdv/p/0vWvyT764SnH3qH/rO6TZHOSc5P8xWLPX5b5nC/wnDwqyc/1Yx+d5HtJ9p+oc9F+n+RjSV7e13bf/nG8ZZH7OTL//v+eRXtMf5vJvr1kL0jXm69L8vB+7L5ZojdP8djel+QdSW7Vvy736+ffPcnXk9yrv92T+tdgn4m6/zLJy9f6s+Xi4uIya5c1L2CWLvn3Ae/H6QPLIuN/KcnVE9Pn5IZfTLZNLLtJ/5/wf1hkXdelD3D99KuSvGLKut+T5FkTdf8gE2Gm/0/23v1/svPv54+zQMCbZuwCdVyd5G799Rdm4gtMkp9N8qMk+07Me2ySD035GJ+d5N3z6vyViekzkpzcX/9gkhMnlj0oywe835mYfl6Sv5035uwkT+qvvzE3DHiXJnnAxPT+/XM3F05bkttNLH9/kuMnpvdKF8IPnuKxnT33Ws+r715Jvjxv3vOTvGFi+rAkPxnq8+My7CWLB7zzkvxBusD/vSS3n1h2nyRf6K/fIV2wuEk//dYkpyxyX49Pct7E9F59X7nbFHXesn8P36KffmOS104sf3CSz/XXnzjvfirJFVk44C05doE6Hp7kk4s9f8t9zqd4nBclOXaizgX7fbofaa5PctOJ5W/L0gHvBv/3ZIke009PBrwle0G63nzuxLIle/Myj23/JD9N/wPivPv8n0n+aN68y9IHwH76xUlevxafJxcXF5dZvqzVvvVjsaN1u5EkSarqJul+IT8q3a+VSbKpqja01n6ywO2vmrvSWvt+dXvZ3WyR+7o63S/gcw5KctZCA/vdY/4wyR3TffG6SZLPTAz5Zmvt+onp7/f3uzld6Ng+sexLi9Sz7Niqem6S49P9qt2S3DyL73p0cLpfd79a/7a34V7z1j+57jum+8V7S7rHtzHdr9KTrpq4PvcY09czzWOcNDn+4CSPqqqHTcy7UbotgQs5OMm7q+qnE/N+ku6L02Lrf2Xd8AyclW6Lwlytiz22g5J8fpEafq6qvj0xb0OSf5qY3pRuqzDjckCSb6X7zN4kyYUTn7FK9z5Ia21bVV2a5GFV9d4kx6TbyrKQ+f1ovyQ3zgLvvX5Xvhen28K1Od0X/rnbzL3fpvqsttZaVS3YE5YbW1U/m+SVSX61r32v/nEsZkWf86p6YpLfS/ejTfrHMNnvFuv3+6X7IfB7E2O/lO6zvJgb/N+TpXvMlQs8ruV6wfx+tFxvXuyx3TrdXgELPc8Hp9t9+BkT8/ZO9zrO2ZRksk4ApiDg7Zo2b/o5SX4+yb1aa1dV1S8l+WQmjgPZBZ9OF9gu6Ke3Z94xb0l3jE2Sv0v3a/b/11q7rj/mYZoadqT7JfmgdLswJt2vyyseW93xdr+f5AHpduX6aVVdPVHH/Odue7pfifebFz4X8z/TPbePba1dW92fj3jkFLdLkq/mhl+eFnuMkybr3Z7ul/3fnfL+tqfbAviR+Quq6pBF1v/iNnESnxVY8H3Rz/9Ca+2wJW57pySf2on7ZJ2qqnumC3gfTndm1x8kuXNrbf6X/jlvT7d1Zq90Jwratsi4Tyc5tKo29p/XbyT5Ybr33vz30OPS7Xb8wHRbyW6RLlhN05Nu8FmtLjksFnyWG/vH6T5nd22tfauqHp7kryaWL9STpvqcV3eM7GvS9buPtdZ+UlUXZfrHeKuquulEyLvtAvVMWqjWBXvMAqbpBfP70Up68/z7unVV3bK19u0Flr24tfbiJW5/pyRjPdsywGCcZGX32pTuC9S3qzuJxh/uxnWfle54ujmvS/LkqnpAf4D9AVX1C+l+Ad0nfQDrt+ZNdRrxfivj/0rywqq6SVUdnu64iJ0ZuyldANyRZGNVnZJuC96cryU5pPpTuLfuVOsfSPKyqrp5/5huX1WTj3nSpiTfSfLd/nE/bZrH2DsjyTOr6sCqulWSk1dw26T7wvGwqvqN6k7YcuP+xAcHLjL+b5K8uP8SmKraXFXHLrH+v0ny/OpPRNGf4OBRU9b22iTPrapfrs4d+vs9P8m1/YkZ9u3rvksfAObcL93uocy4/jP00HTHyb6ltfaZ1tpP04WQV1T/5zD6vjF5EovT0/WLp6XbTXBBrbUr0h0nekQ//dMkr0/y8v4EHhuq6j79D06b0gWEb6bbgvjHK3go70ty56r6rerO5vjMdLv+7czYTUm+m+SaqjogyX+dd/uvpTsebc5KPuc3TReKdiTdia7SHZe8rNbal5JsTfLfq2rvqvqVJA9b5mbzraTHTNMLJutbaW+ef9v3J/nr6k5CdqOqum+/+DVJTqyqe/W96qZV9ZCq2tQ/hhunO9b6H1bwPAAQAW93+4t0B6R/I91xL3+/G9f95iQPrv6sdK2185M8Od0uodekO8Pmwa21a9N9sTkj3a/kj0t3UoVpnZRu15qr0h0b84adHHt2usf/z+l2N/phbrhLzzv7f79ZVZ/orz8xXUC9pK/9XemO4VjIc9M9tmvTfVF4x3IPbMJr+vo+leQT6YLq1Fpr29Ntkfhv6b7QbU/3ZXGxz9Mr070GH6iqa9O9N+61xPrfne4ECqdXdxa7z6Y7i+o0tb0z3e5wb0v33Lwnya37QP7QdMeFfiHde/S16bamzH2ZenCSnfo7jawb7+3fY9vTHXf38nR9Ys7z0gWz8/r31v9Jt9dBkn/9Qv6xdCdIWe4z9aokvz0x/dx0u4JfkG6X0Jem+0y8OV0PuDLdZ/u8aR9Ma+0b6Xbt/JN0AfGwJAtupZpi7H9PdyKha9KFwfmf+5ckeUF1Z3R87ko+5621S5K8LN1z97Ukd12szkU8Ll1P+Fa6HwbfvILbJivoMcv1gkWspDfP99vpjgf8XLrjvZ/d17E13YlZ/qpf57Z0x/PNeViSc1prX5nyfgDozZ3lihlQVX+c5Outtb9Y61oYl/44mINaa7+/1rUwG/qtc59Md3KPNftj54xTVX083cmmPrvWtQDMGgEPAABgJOyiCQAAMBICHgAAwEgIeAAAACMh4AEAAIzEzP2h8/32268dcsgha10GsBtdeOGF32itbV7rOnaF3gTjpD8B69FSvWnmAt4hhxySrVu3rnUZwG5UVV9a6xp2ld4E46Q/AevRUr3JLpoAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBIDBrwquqoqrqsqrZV1ckLLD+uqnZU1UX95SlD1gMAADBmgwW8qtqQ5LQkRyc5PMljq+rwBYa+o7X2S/3ltUPVAwCM0wEH3TZVNdXlgINuu9blAgxq44DrPiLJttba5UlSVacnOTbJJQPeJwCwh/nKFdvz6Fd9dKqx73jqfxy4GoC1NeQumgck2T4xfUU/b75HVNWnq+pdVXXQQiuqqhOqamtVbd2xY8f0BfhFDxjQzvYmgKH57gTrw1p8pobcgjeN9yZ5e2vtR1X11CRvSnL/+YNaa69O8uok2bJlS5t25X7Rg93rgINum69csX35gUl+7sCDcuX2Lw9c0dra2d4EMDTfnWB9WIvP1JAB78okk1vkDuzn/avW2jcnJl+b5E8HrAfYRf7j332EZQBgCEMGvAuSHFZVh6YLdo9J8rjJAVW1f2vtq/3kMUkuHbAegHVDWAYAhjBYwGutXV9VJyU5O8mGJK9vrV1cVacm2dpaOzPJM6vqmCTXJ/lWkuOGqgcAAGDsBj0Gr7V2VpKz5s07ZeL685M8f8gaAAAA9hSD/qFzAAAAVo+ABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMxaMCrqqOq6rKq2lZVJy8x7hFV1apqy5D1AAAAjNlgAa+qNiQ5LcnRSQ5P8tiqOnyBcZuSPCvJx4eqBQAAYE8w5Ba8I5Jsa61d3lr7cZLTkxy7wLg/SvLSJD8csBYAAIDRGzLgHZBk+8T0Ff28f1VV90hyUGvtfQPWAQAAsEdYs5OsVNVeSV6e5DlTjD2hqrZW1dYdO3YMXxzAFPQmYL3Sn2DPNWTAuzLJQRPTB/bz5mxKcpck51TVF5PcO8mZC51opbX26tbaltbals2bNw9YMsD09CZgvdKfYM81ZMC7IMlhVXVoVe2d5DFJzpxb2Fq7prW2X2vtkNbaIUnOS3JMa23rgDUBAACM1mABr7V2fZKTkpyd5NIkZ7TWLq6qU6vqmKHuFwAAYE+1cciVt9bOSnLWvHmnLDL2yCFrAQAAGLs1O8kKAAAAu5eABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIzEoAGvqo6qqsuqaltVnbzA8hOr6jNVdVFVfbiqDh+yHgAAgDEbLOBV1YYkpyU5OsnhSR67QIB7W2vtrq21X0ryp0lePlQ9AAAAYzdVwKuqh1XVSsPgEUm2tdYub639OMnpSY6dHNBa+87E5E2TtBXeBwAAAL1pQ9ujk/xLVf1pVf3ClLc5IMn2iekr+nk3UFVPr6rPp9uC98wp1w0AAMA8UwW81toTktw9yeeTvLGqPlZVJ1TVpl0toLV2Wmvt9kmel+QFC43p72trVW3dsWPHrt4lwG6hNwHrlf4Ee66pd7vsd6d8V7pdLfdP8ptJPlFVz1jkJlcmOWhi+sB+3mJOT/LwRe771a21La21LZs3b562ZIBB6U3AeqU/wZ5r2mPwjq2qdyc5J8mNkhzRWjs6yd2SPGeRm12Q5LCqOrSq9k7ymCRnzlvvYROTD0nyLysrHwAAgDkbpxz3W0le0Vo7d3Jma+37VXX8QjdorV1fVSclOTvJhiSvb61dXFWnJtnaWjszyUlV9cAk1yW5OsmTdvaBAAAA7OmmDXhXzQ93VfXS1trzWmv/uNiNWmtnJTlr3rxTJq4/ayXFAgAAsLhpj8H79QXmHb07CwEAAGDXLLkFr6qeluS/JLl9VX16YtGmJB8ZsjAAAABWZrldNN+W5P1JXpLk5In517bWvjVYVQAAAKzYcgGvtda+WFVPn7+gqm4t5AEAAKwf02zBe2iSC5O0JDWxrCW53UB1AQAAsEJLBrzW2kP7fw9dnXIAAADYWcudZOUeSy1vrX1i95YDAADAzlpuF82XLbGsJbn/bqwFAACAXbDcLpq/tlqFAAAAsGuW20Xz/q21D1bVby20vLX2v4YpCwAAgJVabhfN+yX5YJKHLbCsJRHwAAAA1onldtH8w/7fJ69OOQAAAOysvaYZVFW3qaq/rKpPVNWFVfXKqrrN0MUBAAAwvakCXpLTk+xI8ogkj+yvv2OoogAAAFi55Y7Bm7N/a+2PJqZfVFWPHqIgAAAAds60W/A+UFWPqaq9+st/TnL2kIUBAACwMsv9mYRr050ts5I8O8lb+kV7JflukucOWRwAAADTW+4smptWqxAAAAB2zbTH4KWqbpXksCQ3npvXWjt3iKIAAABYuakCXlU9JcmzkhyY5KIk907ysST3H6wyAAAAVmTak6w8K8k9k3yptfZrSe6e5NtDFQUAAMDKTRvwftha+2GSVNU+rbXPJfn54coCAABgpaY9Bu+Kqrplkvck+YequjrJl4YqCgAAgJWbKuC11n6zv/rCqvpQklsk+fvBqgIAAGDFVnIWzXsk+ZV0fxfvI621Hw9WFQAAACs21TF4VXVKkjcluU2S/ZK8oapeMGRhAAAArMy0W/Aen+RuEyda+ZN0fy7hRQPVBQAAwApNexbNr2TiD5wn2SfJlbu/HAAAAHbWklvwqup/pDvm7pokF1fVP/TTv57k/OHLAwAAYFrL7aK5tf/3wiTvnph/ziDVAAAAsNOWDHittTfNXa+qvZPcsZ+8rLV23ZCFAQAAsDJTnWSlqo5MdxbNLyapJAdV1ZNaa+cOVhkAAAArMu1ZNF+W5EGttcuSpKrumOTtSX55qMIAAABYmWnPonmjuXCXJK21f05yo2FKAgAAYGdMuwXvwqp6bZK39NOPz7+dgAUAAIB1YNqAd2KSpyd5Zj/9T0n+epCKAAAA2CnLBryq2pDkU621X0jy8uFLAgAAYGcsewxea+0nSS6rqtuuQj0AAADspGl30bxVkour6vwk35ub2Vo7ZpCqAAAAWLFpA97/O2gVAAAA7LIlA15V3TjdCVbukOQzSV7XWrt+NQoDAABgZZY7Bu9NSbakC3dHp/uD5wAAAKxDy+2ieXhr7a5JUlWvS3L+8CUBAACwM5bbgnfd3BW7ZgIAAKxvy23Bu1tVfae/Xkn27acrSWut3XzQ6gAAAJjakgGvtbZhtQoBAABg1yz7h84BAACYDQIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMxaMCrqqOq6rKq2lZVJy+w/Peq6pKq+nRV/WNVHTxkPQAAAGM2WMCrqg1JTktydJLDkzy2qg6fN+yTSba01n4xybuS/OlQ9QAAAIzdkFvwjkiyrbV2eWvtx0lOT3Ls5IDW2odaa9/vJ89LcuCA9QAAAIzakAHvgCTbJ6av6Oct5vgk719oQVWdUFVbq2rrjh07dmOJADtPbwLWK/0J9lzr4iQrVfWEJFuS/NlCy1trr26tbWmtbdm8efPqFgewCL0JWK/0J9hzbRxw3VcmOWhi+sB+3g1U1QOT/EGS+7XWfjRgPQAAAKM25Ba8C5IcVlWHVtXeSR6T5MzJAVV19ySvSnJMa+3rA9YCAAAweoMFvNba9UlOSnJ2kkuTnNFau7iqTq2qY/phf5bkZkneWVUXVdWZi6wOAACAZQy5i2Zaa2clOWvevFMmrj9wyPsHAADYk6yLk6wAAACw6wQ8AACAkRDwAAAARkLAAwAAGAkBDwAAYCQEPAAAgJEQ8AAAAEZCwAMAABgJAQ8AAGAkBDwAAICREPAAAABGQsADAAAYCQEPAABgJAQ8AACAkRDwAAAARkLAAwAAGAkBDwAAYCQEPAAAgJEQ8AAAAEZCwAMAABgJAQ8AAGAkBDwAAICREPAAAABGQsADAAAYCQEPAABgJAQ8AACAkRDwAAAARkLAAwAAGAkBDwAAYCQEPAAAgJEQ8AAAAEZCwAMAABgJAQ8AAGAkBDwAAICREPAAAABGQsADAAAYCQEPAABgJAQ8AACAkRDwAAAARkLAAwAAGAkBDwAAYCQEPAAAgJEQ8AAAAEZCwAMAABgJAQ8AAGAkBDwAAICREPAAAABGQsADAAAYCQEPAABgJAQ8AACAkRDwAAAARkLAAwAAGAkBDwAAYCQGDXhVdVRVXVZV26rq5AWW37eqPlFV11fVI4esBQAAYOwGC3hVtSHJaUmOTnJ4ksdW1eHzhn05yXFJ3jZUHQAAAHuKjQOu+4gk21prlydJVZ2e5Ngkl8wNaK19sV/20wHrAAAA2CMMuYvmAUm2T0xf0c9bsao6oaq2VtXWHTt27JbiAHaV3gSsV/oT7Llm4iQrrbVXt9a2tNa2bN68ea3LAUiiNwHrl/4Ee64hA96VSQ6amD6wnwcAAMAAhgx4FyQ5rKoOraq9kzwmyZkD3h8AAMAebbCA11q7PslJSc5OcmmSM1prF1fVqVV1TJJU1T2r6ookj0ryqqq6eKh6AAAAxm7Is2imtXZWkrPmzTtl4voF6XbdBAAAYBfNxElWAAAAWJ6ABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMh4AEAAIyEgAcAADASAh4AAMBICHgAAAAjIeABAACMhIAHAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBICHgAAwEgIeAAAACMxaMCrqqOq6rKq2lZVJy+wfJ+qeke//ONVdciQ9QAAAIzZYAGvqjYkOS3J0UkOT/LYqjp83rDjk1zdWrtDklckeelQ9QAAAIzdkFvwjkiyrbV2eWvtx0lOT3LsvDHHJnlTf/1dSR5QVTVgTQAAAKM1ZMA7IMn2iekr+nkLjmmtXZ/kmiS3GbAmAACA0arW2jArrnpkkqNaa0/pp387yb1aaydNjPlsP+aKfvrz/ZhvzFvXCUlO6Cd/PsllU5axX5JvLDtqfVHz6pi1mmet3mRlNR/cWts8ZDFD2IXelMzeazpr9SZqXi2zVvNK693T+tOsvZ6JmlfDrNWbjL/mRXvTkAHvPkle2Fr7jX76+UnSWnvJxJiz+zEfq6qNSa5KsrntpqKqamtrbcvuWNdqUfPqmLWaZ63eZDZrXk2z9vzMWr2JmlfLrNU8a/Wutll8ftQ8vFmrN9mzax5yF80LkhxWVYdW1d5JHpPkzHljzkzypP76I5N8cHeFOwAAgD3NxqFW3Fq7vqpOSnJ2kg1JXt9au7iqTk2ytbV2ZpLXJfnbqtqW5FvpQiAAAAA7YbCAlySttbOSnDVv3ikT13+Y5FEDlvDqAdc9FDWvjlmredbqTWaz5tU0a8/PrNWbqHm1zFrNs1bvapvF50fNw5u1epM9uObBjsEDAABgdQ15DB4AAACraBQBr6qOqqrLqmpbVZ28wPJ9quod/fKPV9Uha1Dm/JqWq/n3quqSqvp0Vf1jVR28FnXOq2nJmifGPaKqWlWt6ZmLpqm3qv5z/zxfXFVvW+0aF6hnuffFbavqQ1X1yf698eC1qHOintdX1df7P3my0PKqqr/sH8+nq+oeq13jWtKbVses9aa+lpnqT7PWm/qa9Kcl6E/D05tWx6z1p1XpTa21mb6kO4HL55PcLsneST6V5PB5Y/5Lkr/prz8myTtmoOZfS3KT/vrTZqHmftymJOcmOS/JlvVcb5LDknwyya366Z9Z789xun2zn9ZfPzzJF9e45vsmuUeSzy6y/MFJ3p+kktw7ycfXst51+HrqTatQcz9uXfSmFTzP66Y/zWJv6uvQn3btNdWfBq63H6c3DV/zuupPq9GbxrAF74gk21prl7fWfpzk9CTHzhtzbJI39dffleQBVVWrWON8y9bcWvtQa+37/eR5SQ5c5Rrnm+Z5TpI/SvLSJD9czeIWME29v5vktNba1UnSWvv6Ktc43zQ1tyQ376/fIslXVrG+f6e1dm66M+Au5tgkb26d85Lcsqr2X53q1pzetDpmrTcls9efZq43JfrTMvSn4elNq2Pm+tNq9KYxBLwDkmyfmL6in7fgmNba9UmuSXKbValuYdPUPOn4dEl+LS1bc78J+aDW2vtWs7BFTPMc3zHJHavqI1V1XlUdtWrVLWyaml+Y5AlVdUW6M9Q+Y3VK22krfa+Pid60OmatNyWz15/G2JsS/Ul/GpbetDrG2J92uTcN+mcS2HVV9YQkW5Lcb61rWUpV7ZXk5UmOW+NSVmJjul0Njkz3K9+5VXXX1tq317KoZTw2yRtbay+rqvuk+zuSd2mt/XStC2PPojcNbtb6k97EujEL/UlvWlV7XH8awxa8K5McNDF9YD9vwTFVtTHd5tlvrkp1C5um5lTVA5P8QZJjWms/WqXaFrNczZuS3CXJOVX1xXT7DJ+5hgcMT/McX5HkzNbada21LyT553RNa61MU/PxSc5Iktbax5LcOMl+q1LdzpnqvT5SetPqmLXelMxefxpjb0r0J/1pWHrT6hhjf9r13jTEwYOreUn3S8LlSQ7Nvx1ceed5Y56eGx4ofMYM1Hz3dAeNHrbWz/G0Nc8bf07W9iQr0zzHRyV5U399v3Sbw2+zzmt+f5Lj+ut3Srcfea3xe+OQLH6g8ENywwOFz1/LWtfh66k3rULN88avaW9awfO8bvrTrPamvhb9aedfU/1p4Hrnjdebhqt53fWnoXvTmj2w3fwkPTjdLwifT/IH/bxT0/16k3RJ/Z1JtiU5P8ntZqDm/5Pka0ku6i9nrvea541dD41quee40u0ecUmSzyR5zHp/jtOd/ekjfQO7KMmD1rjetyf5apLr0v2qd3ySE5OcOPEcn9Y/ns+s9XtiHb6eetMq1Dxv7Jr3pimf53XVn2atN/U16U+79prqTwPXO2+s3jRczeuqP61Gb6p+RQAAAMy4MRyDBwAAQAQ8AACA0RDwAAAARkLAAwAAGAkBDwAAYCQEPAAAgJEQ8JhKVX10wHU/qqouraoPDXUfwDjpTcB6pT+xVvwdPFZFVW1orf1kkWV/n+RFrbUPT7muja2163drgcAeSW8C1iv9iZ1lCx5Tqarv9v/uX1XnVtVFVfXZqvrVpW5TVS+rqk8luU9VPaGqzu9v+6qq2lBVpyT5lSSvq6o/6+f9WVVdUFWfrqqn9us6sqr+qarOTHLJMuPOqap3VdXnquqtVVX9sntW1Uer6lN9HZsWWw8wG/QmYL3Sn1grG9e6AGbO45Kc3Vp7cVVtSHKTJcbeNMnHW2vPqao7JXlekv/UWruuqv46yeNba6dW1f2TPLe1trWqTkhyTWvtnlW1T5KPVNUH+vXdI8ldWmtfWGbc3ZPcOclXknwkyX+qqvOTvCPJo1trF1TVzZP8IMnxC62ntfaF3faMAatBbwLWK/2JVSXgsVIXJHl9Vd0oyXtaaxctMfYnSf6uv/6AJL+c5IL+R6F9k3x9gds8KMkvVtUj++lbJDksyY+TnD/RPJYbd0WSVNVFSQ5Jck2Sr7bWLkiS1tp3+uWLrUeTgtmiNwHrlf7EqhLwWJHW2rlVdd8kD0nyxqp6eWvtzYsM/+HEvuOV5E2ttecvcxeV5BmttbNvMLPqyCTfm3LcjyZm/SRLv88XXA8wW/QmYL3Sn1htjsFjRarq4CRfa629Jslr0236n8Y/JnlkVf1Mv55b9+ua7+wkT+t/5UpV3bGqbroL4+ZclmT/qrpnP35TVW3cifUA65DeBKxX+hOrzRY8VurIJP+1qq5L8t0kT5zmRq21S6rqBUk+UFV7JbkuydOTfGne0Nem2y3gE9Xtj7AjycMXWOW04+bu/8dV9egk/6Oq9k23D/kDV7oeYN06MnoTsD4dGf2JVeTPJAAAAIyEXTQBAABGwi6a7LKq+niSfebN/u3W2mfWoh6ARG8C1i/9iSHZRRMAAGAk7KIJAAAwEgIeAADASAh4AAAAIyHgAQAAjISABwAAMBL/P1ZsmEv4J1fXAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x432 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, sharex=True, sharey=True, figsize=(15, 6))\n",
+    "\n",
+    "hist_kwargs = {\"bins\": 20, \"stat\": \"probability\"}\n",
+    "\n",
+    "ax = axes[0]\n",
+    "ax.set_title(\"Train (candidate and reference)\")\n",
+    "sns.histplot(train_data[\"is_reference\"], ax=ax, **hist_kwargs);\n",
+    "\n",
+    "ax = axes[1]\n",
+    "ax.set_title(\"Dev (candidate and reference)\")\n",
+    "sns.histplot(dev_data[\"is_reference\"], ax=ax, **hist_kwargs);\n",
+    "\n",
+    "ax = axes[2]\n",
+    "sns.histplot(test_data[\"is_reference\"], ax=ax, **hist_kwargs);\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "152a5bcf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>question</th>\n",
+       "      <th>context</th>\n",
+       "      <th>answer</th>\n",
+       "      <th>is_reference</th>\n",
+       "      <th>correctness</th>\n",
+       "      <th>correctness_std</th>\n",
+       "      <th>_metadata</th>\n",
+       "      <th>dataset</th>\n",
+       "      <th>example_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>What's a possible reason the guy stares into t...</td>\n",
+       "      <td>Somewhere in me I knew it all along , there ar...</td>\n",
+       "      <td>Because he likes her a lot .</td>\n",
+       "      <td>True</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>cosmosqa</td>\n",
+       "      <td>002b5d9aa346d492b02705ae2c9f4abd__orig</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>What's a possible reason the guy stares into t...</td>\n",
+       "      <td>Somewhere in me I knew it all along , there ar...</td>\n",
+       "      <td>He's a child and it's a very rare thing.</td>\n",
+       "      <td>False</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{'scores': [1], 'source': 'gpt2'}</td>\n",
+       "      <td>cosmosqa</td>\n",
+       "      <td>002b5d9aa346d492b02705ae2c9f4abd__cand</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>What might be different if the friend didn't g...</td>\n",
+       "      <td>Her dog and another kitten kept trying to esca...</td>\n",
+       "      <td>Two of the kittens wouldn't have been killed</td>\n",
+       "      <td>True</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>cosmosqa</td>\n",
+       "      <td>00336fecc378c067330935b63ce0351d__orig</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>What may be your reason for leaving the Malays...</td>\n",
+       "      <td>I know because some of the things learnt in Mo...</td>\n",
+       "      <td>It didn't offer an accurate representation of ...</td>\n",
+       "      <td>True</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>cosmosqa</td>\n",
+       "      <td>003950650438f8a6446095e8f7c8e0bd__orig</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>What may be your reason for leaving the Malays...</td>\n",
+       "      <td>I know because some of the things learnt in Mo...</td>\n",
+       "      <td>it does not have a clear idea about culture in...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{'scores': [3], 'source': 'backtranslation'}</td>\n",
+       "      <td>cosmosqa</td>\n",
+       "      <td>003950650438f8a6446095e8f7c8e0bd__cand</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49708</th>\n",
+       "      <td>How would you describe Jesse?</td>\n",
+       "      <td>Jesse ate their cereal and didn't leave any fo...</td>\n",
+       "      <td>selfish</td>\n",
+       "      <td>True</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>socialiqa</td>\n",
+       "      <td>fffb5bf0cbb536ab6a767396015ac98b__orig</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49709</th>\n",
+       "      <td>How would you describe Jesse?</td>\n",
+       "      <td>Jesse ate their cereal and didn't leave any fo...</td>\n",
+       "      <td>confident</td>\n",
+       "      <td>False</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{'scores': [1], 'source': 'gpt2'}</td>\n",
+       "      <td>socialiqa</td>\n",
+       "      <td>fffb5bf0cbb536ab6a767396015ac98b__cand</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49710</th>\n",
+       "      <td>What does Addison need to do before this?</td>\n",
+       "      <td>Addison was looking for their teddy bear. Addi...</td>\n",
+       "      <td>have a stuffed bear</td>\n",
+       "      <td>True</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>socialiqa</td>\n",
+       "      <td>fffc03fc5f061ad5cc913108eef37ae4__orig</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49711</th>\n",
+       "      <td>What does Addison need to do before this?</td>\n",
+       "      <td>Addison was looking for their teddy bear. Addi...</td>\n",
+       "      <td>have their teddy bear lying there</td>\n",
+       "      <td>False</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{'scores': [3], 'source': 'gpt2'}</td>\n",
+       "      <td>socialiqa</td>\n",
+       "      <td>fffc03fc5f061ad5cc913108eef37ae4__cand</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49712</th>\n",
+       "      <td>How would Jan feel as a result?</td>\n",
+       "      <td>Kendall finally settled his divorce with Jan b...</td>\n",
+       "      <td>completely broke</td>\n",
+       "      <td>False</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>{'scores': [4], 'source': 'backtranslation'}</td>\n",
+       "      <td>socialiqa</td>\n",
+       "      <td>ffff958eeb017631c50f371d7dbd7771__cand</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>49713 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                question  \\\n",
+       "0      What's a possible reason the guy stares into t...   \n",
+       "1      What's a possible reason the guy stares into t...   \n",
+       "2      What might be different if the friend didn't g...   \n",
+       "3      What may be your reason for leaving the Malays...   \n",
+       "4      What may be your reason for leaving the Malays...   \n",
+       "...                                                  ...   \n",
+       "49708                      How would you describe Jesse?   \n",
+       "49709                      How would you describe Jesse?   \n",
+       "49710          What does Addison need to do before this?   \n",
+       "49711          What does Addison need to do before this?   \n",
+       "49712                    How would Jan feel as a result?   \n",
+       "\n",
+       "                                                 context  \\\n",
+       "0      Somewhere in me I knew it all along , there ar...   \n",
+       "1      Somewhere in me I knew it all along , there ar...   \n",
+       "2      Her dog and another kitten kept trying to esca...   \n",
+       "3      I know because some of the things learnt in Mo...   \n",
+       "4      I know because some of the things learnt in Mo...   \n",
+       "...                                                  ...   \n",
+       "49708  Jesse ate their cereal and didn't leave any fo...   \n",
+       "49709  Jesse ate their cereal and didn't leave any fo...   \n",
+       "49710  Addison was looking for their teddy bear. Addi...   \n",
+       "49711  Addison was looking for their teddy bear. Addi...   \n",
+       "49712  Kendall finally settled his divorce with Jan b...   \n",
+       "\n",
+       "                                                  answer  is_reference  \\\n",
+       "0                           Because he likes her a lot .          True   \n",
+       "1               He's a child and it's a very rare thing.         False   \n",
+       "2           Two of the kittens wouldn't have been killed          True   \n",
+       "3      It didn't offer an accurate representation of ...          True   \n",
+       "4      it does not have a clear idea about culture in...         False   \n",
+       "...                                                  ...           ...   \n",
+       "49708                                            selfish          True   \n",
+       "49709                                          confident         False   \n",
+       "49710                                have a stuffed bear          True   \n",
+       "49711                  have their teddy bear lying there         False   \n",
+       "49712                                   completely broke         False   \n",
+       "\n",
+       "       correctness  correctness_std  \\\n",
+       "0                5              0.0   \n",
+       "1                1              0.0   \n",
+       "2                5              0.0   \n",
+       "3                5              0.0   \n",
+       "4                3              0.0   \n",
+       "...            ...              ...   \n",
+       "49708            5              0.0   \n",
+       "49709            1              0.0   \n",
+       "49710            5              0.0   \n",
+       "49711            3              0.0   \n",
+       "49712            4              0.0   \n",
+       "\n",
+       "                                          _metadata    dataset  \\\n",
+       "0                                                {}   cosmosqa   \n",
+       "1                 {'scores': [1], 'source': 'gpt2'}   cosmosqa   \n",
+       "2                                                {}   cosmosqa   \n",
+       "3                                                {}   cosmosqa   \n",
+       "4      {'scores': [3], 'source': 'backtranslation'}   cosmosqa   \n",
+       "...                                             ...        ...   \n",
+       "49708                                            {}  socialiqa   \n",
+       "49709             {'scores': [1], 'source': 'gpt2'}  socialiqa   \n",
+       "49710                                            {}  socialiqa   \n",
+       "49711             {'scores': [3], 'source': 'gpt2'}  socialiqa   \n",
+       "49712  {'scores': [4], 'source': 'backtranslation'}  socialiqa   \n",
+       "\n",
+       "                                   example_id  \n",
+       "0      002b5d9aa346d492b02705ae2c9f4abd__orig  \n",
+       "1      002b5d9aa346d492b02705ae2c9f4abd__cand  \n",
+       "2      00336fecc378c067330935b63ce0351d__orig  \n",
+       "3      003950650438f8a6446095e8f7c8e0bd__orig  \n",
+       "4      003950650438f8a6446095e8f7c8e0bd__cand  \n",
+       "...                                       ...  \n",
+       "49708  fffb5bf0cbb536ab6a767396015ac98b__orig  \n",
+       "49709  fffb5bf0cbb536ab6a767396015ac98b__cand  \n",
+       "49710  fffc03fc5f061ad5cc913108eef37ae4__orig  \n",
+       "49711  fffc03fc5f061ad5cc913108eef37ae4__cand  \n",
+       "49712  ffff958eeb017631c50f371d7dbd7771__cand  \n",
+       "\n",
+       "[49713 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ed2d3146",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'df' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [13]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdf\u001b[49m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'df' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c876afc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame([example, example])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcb8e648",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -297,7 +737,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/training_config/mocha_eqqa.jsonnet
+++ b/training_config/mocha_eqqa.jsonnet
@@ -52,7 +52,7 @@ local num_gpus = 1;
       "num_gradient_accumulation_steps": num_gradient_accumulation_steps,
       "patience": epochs,
       "enable_default_callbacks": false,
-      "use_amp": true,
+      "use_amp": false,
       "cuda_device": 0
     },
     "pytorch_seed": 15371,

--- a/training_config/mocha_eqqa.jsonnet
+++ b/training_config/mocha_eqqa.jsonnet
@@ -3,8 +3,8 @@ local epochs = 10;
 local batch_size = 1;
 local num_gradient_accumulation_steps = 2;
 
-local train_data_path = "./data/mocha_eqqa_data/split__train_all.json";
-local dev_data_path = "./data/mocha_eqqa_data/split__dev_all.json";
+local train_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__dev_candidates_only.json";
+local dev_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__dev_candidates_only.json";
 
 local training_data_size = 520;
 local num_gpus = 1;
@@ -24,7 +24,8 @@ local num_gpus = 1;
         "type": "empty"
     },
     "model": {
-        "type": "mocha_eqqa",
+        "type": "mocha_eqqa_roberta",
+        "hidden_size": 512,
     },
     "data_loader": {
         "batch_size": batch_size

--- a/training_config/mocha_eqqa.jsonnet
+++ b/training_config/mocha_eqqa.jsonnet
@@ -1,0 +1,55 @@
+local transformer_model = "roberta-base";
+local epochs = 10;
+local batch_size = 1;
+local num_gradient_accumulation_steps = 2;
+
+local train_data_path = "./data/mocha_eqqa_data/split__train_all.json";
+local dev_data_path = "./data/mocha_eqqa_data/split__dev_all.json";
+
+local training_data_size = 520;
+local num_gpus = 1;
+
+{
+    "dataset_reader": {
+        "type": "mocha_eqqa",
+        "transformer_model_name": transformer_model,
+        "max_answer_length": 100,
+        "max_query_length": 100,
+        "max_document_length": 512,
+        "include_context": true
+    },
+    "train_data_path": train_data_path,
+    "validation_data_path": dev_data_path,
+    "vocabulary": {
+        "type": "empty"
+    },
+    "model": {
+        "type": "mocha_eqqa",
+    },
+    "data_loader": {
+        "batch_size": batch_size
+    },
+    "trainer": {
+      "optimizer": {
+        "type": "adam",
+        "lr": 5e-5
+      },
+      "learning_rate_scheduler": {
+        "type": "slanted_triangular",
+        "num_epochs": epochs,
+        "cut_frac": 0.1,
+        "num_steps_per_epoch": std.ceil(training_data_size / (batch_size * num_gradient_accumulation_steps * num_gpus))
+      },
+      "callbacks": [
+	{"type": "tensorboard"}
+      ],
+      "grad_clipping": 1.0,
+      "num_epochs": epochs,
+      "num_gradient_accumulation_steps": num_gradient_accumulation_steps,
+      "patience": epochs,
+      "enable_default_callbacks": false,
+      "use_amp": true,
+      "cuda_device": 0
+    },
+    "pytorch_seed": 15371,
+}

--- a/training_config/mocha_eqqa.jsonnet
+++ b/training_config/mocha_eqqa.jsonnet
@@ -1,6 +1,6 @@
 local transformer_model = "roberta-base";
 local epochs = 10;
-local batch_size = 64;
+local batch_size = 16;
 local num_gradient_accumulation_steps = 1;
 
 local train_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__train_candidates_only.json";

--- a/training_config/mocha_eqqa.jsonnet
+++ b/training_config/mocha_eqqa.jsonnet
@@ -1,12 +1,12 @@
 local transformer_model = "roberta-base";
 local epochs = 10;
-local batch_size = 1;
-local num_gradient_accumulation_steps = 2;
+local batch_size = 64;
+local num_gradient_accumulation_steps = 1;
 
 local train_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__train_candidates_only.json";
 local dev_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__dev_candidates_only.json";
 
-local training_data_size = 520;
+local training_data_size = 512;
 local num_gpus = 1;
 
 {
@@ -25,15 +25,18 @@ local num_gpus = 1;
     },
     "model": {
         "type": "mocha_eqqa_roberta",
-        "hidden_size": 512,
+        "hidden_size": 256,
+        "train_base": true
     },
     "data_loader": {
         "batch_size": batch_size
     },
     "trainer": {
       "optimizer": {
-        "type": "adam",
-        "lr": 5e-5
+        "type": "huggingface_adamw",
+        "weight_decay": 0.0,
+        "lr": 5e-4,
+        "eps": 1e-8
       },
       "learning_rate_scheduler": {
         "type": "slanted_triangular",

--- a/training_config/mocha_eqqa.jsonnet
+++ b/training_config/mocha_eqqa.jsonnet
@@ -3,7 +3,7 @@ local epochs = 10;
 local batch_size = 1;
 local num_gradient_accumulation_steps = 2;
 
-local train_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__dev_candidates_only.json";
+local train_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__train_candidates_only.json";
 local dev_data_path = "/home/kat/Projects/PhD/qasper-experiments/eqqa/data/mocha_eqqa_data/split__dev_candidates_only.json";
 
 local training_data_size = 520;


### PR DESCRIPTION
Goal: Implement MOCHA reader and Roberta-base regression model

Main changes
- Add `training_config/mocha_eqqa.jsonnet`: Configuration file for the MOCHA-ROBERTA QE experiment.
- Add `quality_estimation/mocha_eqqa_reader.py`: MOCHA dataset reader. This considers the preprocessed version of the [files available here]([here](https://drive.google.com/file/d/1tUyjF7QX3ZAozy0-uhyhtpegzWGt-diU/view?usp=sharing)).
- Add `quality_estimation/mocha_eqqa_roberta_model.py`: a roberta-base transformer with a regression layer on top.